### PR TITLE
Add interactive Sinhala exercise suite

### DIFF
--- a/src/exercises/Dialogue/config.json
+++ b/src/exercises/Dialogue/config.json
@@ -1,0 +1,50 @@
+{
+  "id": "dialogue-1",
+  "prompt": "Practice a morning greeting",
+  "instructions": "Follow the conversation and choose the best reply.",
+  "initialMessage": "Respond in Sinhala to keep the dialogue flowing.",
+  "turnSuccessMessage": "Nice answer!",
+  "turnErrorMessage": "Try a different reply.",
+  "successMessage": "You completed the dialogue!",
+  "turns": [
+    {
+      "type": "statement",
+      "role": "tutor",
+      "speaker": "Friend",
+      "text": "සුභ උදෑසනක්!",
+      "delay": 300
+    },
+    {
+      "type": "choice",
+      "answers": ["සුභ උදෑසනක්"],
+      "options": [
+        { "label": "සුභ උදෑසනක්" },
+        { "label": "සුභ රාත්‍රියක්", "followUp": { "text": "අද උදේයි, නැවත උත්සාහ කරන්න!", "role": "tutor", "speaker": "Friend" } },
+        { "label": "ඔබට කොහොම ද?", "followUp": { "text": "උදේදී සාදරයෙන් සුභ පැතීම හොඳයි!", "role": "tutor", "speaker": "Friend" } }
+      ],
+      "delay": 400
+    },
+    {
+      "type": "statement",
+      "role": "tutor",
+      "speaker": "Friend",
+      "text": "ඔබට කොහොම ද?",
+      "delay": 300
+    },
+    {
+      "type": "choice",
+      "answers": ["මම හොඳින්"],
+      "options": [
+        { "label": "මම හොඳින්" },
+        { "label": "මට යන්න ඕන" }
+      ],
+      "delay": 400
+    },
+    {
+      "type": "statement",
+      "role": "tutor",
+      "speaker": "Friend",
+      "text": "ඒක සතුටක්!"
+    }
+  ]
+}

--- a/src/exercises/Dialogue/index.js
+++ b/src/exercises/Dialogue/index.js
@@ -1,0 +1,175 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="dialogue"]';
+const STYLESHEET_ID = 'dialogue-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'dialogue';
+
+  const surface = document.createElement('div');
+  surface.className = 'dialogue__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'dialogue__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'dialogue__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'dialogue__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  const transcript = document.createElement('div');
+  transcript.className = 'dialogue__transcript';
+  surface.appendChild(transcript);
+
+  const choices = document.createElement('div');
+  choices.className = 'dialogue__choices';
+  surface.appendChild(choices);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'dialogue__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  return {
+    wrapper,
+    transcript,
+    choices,
+    feedback,
+  };
+}
+
+function addBubble(container, turn, role = 'tutor') {
+  const bubble = document.createElement('div');
+  bubble.className = `dialogue__bubble dialogue__bubble--${role}`;
+
+  if (turn.avatar) {
+    const avatar = document.createElement('img');
+    avatar.className = 'dialogue__avatar';
+    avatar.src = turn.avatar;
+    avatar.alt = `${turn.speaker || role} avatar`;
+    bubble.appendChild(avatar);
+  }
+
+  const content = document.createElement('div');
+  content.className = 'dialogue__content';
+
+  const speaker = document.createElement('span');
+  speaker.className = 'dialogue__speaker';
+  speaker.textContent = turn.speaker || (role === 'user' ? 'You' : 'Tutor');
+  content.appendChild(speaker);
+
+  const text = document.createElement('p');
+  text.className = 'dialogue__text';
+  text.textContent = turn.text;
+  content.appendChild(text);
+
+  bubble.appendChild(content);
+  container.appendChild(bubble);
+  container.scrollTop = container.scrollHeight;
+}
+
+export async function initDialogueExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('Dialogue requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('Dialogue target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, transcript, choices, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  let index = 0;
+  let completed = false;
+
+  function runTurn() {
+    if (index >= config.turns.length) {
+      completed = true;
+      setStatusMessage(feedback, config.successMessage, 'success');
+      if (typeof onComplete === 'function') {
+        onComplete({});
+      }
+      return;
+    }
+
+    const turn = config.turns[index];
+
+    if (turn.type === 'statement') {
+      addBubble(transcript, turn, turn.role || 'tutor');
+      index += 1;
+      window.setTimeout(runTurn, turn.delay || 400);
+      return;
+    }
+
+    if (turn.type === 'choice') {
+      choices.innerHTML = '';
+      turn.options.forEach((option) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'dialogue__choice';
+        button.textContent = option.label;
+        button.addEventListener('click', () => {
+          if (completed) return;
+          addBubble(transcript, { speaker: 'You', text: option.label }, 'user');
+          const normalised = normaliseAnswer(option.value || option.label);
+          const answers = (turn.answers || []).map(normaliseAnswer);
+          if (answers.includes(normalised)) {
+            setStatusMessage(feedback, turn.successMessage || config.turnSuccessMessage || 'Great reply!', 'success');
+            index += 1;
+            choices.innerHTML = '';
+            window.setTimeout(runTurn, turn.delay || 500);
+          } else if (option.followUp) {
+            addBubble(transcript, option.followUp, option.followUp.role || 'tutor');
+            setStatusMessage(feedback, turn.errorMessage || config.turnErrorMessage || 'Try a different response.', 'error');
+          } else {
+            setStatusMessage(feedback, turn.errorMessage || config.turnErrorMessage || 'Try a different response.', 'error');
+          }
+        });
+        choices.appendChild(button);
+      });
+      return;
+    }
+
+    index += 1;
+    runTurn();
+  }
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+  runTurn();
+
+  return {
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.Dialogue = initDialogueExercise;
+}
+
+export default initDialogueExercise;

--- a/src/exercises/Dialogue/styles.css
+++ b/src/exercises/Dialogue/styles.css
@@ -1,0 +1,163 @@
+.dialogue {
+  --exercise-bg: #1f2c3d;
+  --exercise-surface: #101823;
+  --exercise-text: #f5faff;
+  --exercise-muted: rgba(245, 250, 255, 0.7);
+  --exercise-accent: #00bcd4;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at bottom right, rgba(0, 188, 212, 0.18), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.dialogue__surface {
+  width: min(680px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.9rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.dialogue__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.dialogue__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.dialogue__instructions {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--exercise-muted);
+}
+
+.dialogue__transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.dialogue__bubble {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.dialogue__bubble--user {
+  flex-direction: row-reverse;
+}
+
+.dialogue__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.dialogue__content {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 0.85rem 1.1rem;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+  max-width: 85%;
+}
+
+.dialogue__bubble--user .dialogue__content {
+  background: rgba(0, 188, 212, 0.22);
+}
+
+.dialogue__speaker {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--exercise-muted);
+  margin-bottom: 0.25rem;
+}
+
+.dialogue__text {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.dialogue__choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.dialogue__choice {
+  border-radius: 18px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.85rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.dialogue__choice:hover,
+.dialogue__choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(0, 188, 212, 0.8);
+  outline: none;
+}
+
+.dialogue__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.dialogue__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.dialogue__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.dialogue__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+@media (max-width: 640px) {
+  .dialogue {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .dialogue__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .dialogue__choices {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/exercises/FillBlank/config.json
+++ b/src/exercises/FillBlank/config.json
@@ -1,0 +1,15 @@
+{
+  "id": "fill-blank-1",
+  "prompt": "Fill in the missing word",
+  "instructions": "Choose the word that best completes the sentence.",
+  "sentence": {
+    "before": "මම",
+    "after": "යමි"
+  },
+  "choices": ["පාසලට", "වතුර", "කිරි"],
+  "answers": ["පාසලට"],
+  "blankPlaceholder": "_____",
+  "successMessage": "Nice! The sentence means ‘I go to school’.",
+  "errorMessage": "Try another option.",
+  "initialMessage": "Remember Sinhala uses postpositions after nouns."
+}

--- a/src/exercises/FillBlank/index.js
+++ b/src/exercises/FillBlank/index.js
@@ -1,0 +1,141 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  createChoiceButton,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="fill-blank"]';
+const STYLESHEET_ID = 'fill-blank-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'fill-blank';
+
+  const surface = document.createElement('div');
+  surface.className = 'fill-blank__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'fill-blank__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'fill-blank__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const sentence = document.createElement('p');
+  sentence.className = 'fill-blank__sentence';
+
+  const before = document.createElement('span');
+  before.className = 'fill-blank__before';
+  before.textContent = config.sentence.before;
+  sentence.appendChild(before);
+
+  const blank = document.createElement('span');
+  blank.className = 'fill-blank__blank';
+  blank.textContent = config.blankPlaceholder || '_____';
+  sentence.appendChild(blank);
+
+  const after = document.createElement('span');
+  after.className = 'fill-blank__after';
+  after.textContent = config.sentence.after;
+  sentence.appendChild(after);
+
+  surface.appendChild(sentence);
+
+  const choices = document.createElement('div');
+  choices.className = 'fill-blank__choices';
+  surface.appendChild(choices);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'fill-blank__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'fill-blank__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  return {
+    wrapper,
+    blank,
+    choices,
+    feedback,
+  };
+}
+
+export async function initFillBlankExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('FillBlank requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('FillBlank target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, blank, choices, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const answers = new Set(config.answers.map(normaliseAnswer));
+  let completed = false;
+
+  const buttons = config.choices.map((choice) =>
+    createChoiceButton({
+      label: choice,
+      value: choice,
+      className: 'fill-blank__choice',
+      onClick: (value, button) => {
+        if (completed) return;
+        const normalised = normaliseAnswer(value);
+        blank.textContent = value;
+        if (answers.has(normalised)) {
+          completed = true;
+          button.classList.add('fill-blank__choice--correct');
+          buttons.forEach((btn) => {
+            btn.disabled = true;
+            if (btn !== button) {
+              btn.classList.add('fill-blank__choice--disabled');
+            }
+          });
+          setStatusMessage(feedback, config.successMessage, 'success');
+          if (typeof onComplete === 'function') {
+            onComplete({ value });
+          }
+        } else {
+          button.classList.add('fill-blank__choice--incorrect');
+          setStatusMessage(feedback, config.errorMessage, 'error');
+        }
+      },
+    })
+  );
+
+  buttons.forEach((button) => choices.appendChild(button));
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return {
+    buttons,
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.FillBlank = initFillBlankExercise;
+}
+
+export default initFillBlankExercise;

--- a/src/exercises/FillBlank/styles.css
+++ b/src/exercises/FillBlank/styles.css
@@ -1,0 +1,146 @@
+.fill-blank {
+  --exercise-bg: #3d2f1d;
+  --exercise-surface: #241a0f;
+  --exercise-text: #fffaf1;
+  --exercise-muted: rgba(255, 250, 241, 0.7);
+  --exercise-accent: #f9a825;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top right, rgba(249, 168, 37, 0.2), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.fill-blank__surface {
+  width: min(560px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.fill-blank__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.fill-blank__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.fill-blank__sentence {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.5vw, 2.1rem);
+  font-weight: 600;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.fill-blank__blank {
+  min-width: 120px;
+  text-align: center;
+  padding: 0.3rem 0.6rem;
+  border-radius: 12px;
+  border: 2px dashed rgba(249, 168, 37, 0.4);
+  background: rgba(249, 168, 37, 0.12);
+}
+
+.fill-blank__choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.85rem;
+}
+
+.fill-blank__choice {
+  border-radius: 18px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+  padding: 0.85rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.fill-blank__choice:hover,
+.fill-blank__choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(249, 168, 37, 0.8);
+  outline: none;
+}
+
+.fill-blank__choice--correct {
+  border-color: rgba(255, 213, 79, 0.95);
+  background: rgba(249, 168, 37, 0.25);
+  color: #2a1b05;
+}
+
+.fill-blank__choice--incorrect {
+  border-color: rgba(255, 122, 122, 0.9);
+  background: rgba(255, 122, 122, 0.18);
+}
+
+.fill-blank__choice--disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.fill-blank__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.fill-blank__feedback[data-status='success'] {
+  color: rgba(255, 213, 79, 0.95);
+}
+
+.fill-blank__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.fill-blank__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.fill-blank__instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--exercise-muted);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .fill-blank {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .fill-blank__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .fill-blank__choices {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/exercises/Listening/config.json
+++ b/src/exercises/Listening/config.json
@@ -1,0 +1,11 @@
+{
+  "id": "listening-1",
+  "prompt": "Listen and choose the correct translation",
+  "instructions": "Tap play and choose what you hear in Sinhala.",
+  "audioSrc": "/es_man.mp3",
+  "choices": ["හෙලෝ", "ආයුබෝවන්", "සුභ සන්ධ්‍යා වෙලාවක්"],
+  "answers": ["ආයුබෝවන්"],
+  "successMessage": "Great ear! You picked the correct phrase.",
+  "errorMessage": "Listen again and try another option.",
+  "initialMessage": "You can replay the audio as many times as you like."
+}

--- a/src/exercises/Listening/index.js
+++ b/src/exercises/Listening/index.js
@@ -1,0 +1,185 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  createChoiceButton,
+  createAudio,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="listening"]';
+const STYLESHEET_ID = 'listening-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'listening';
+
+  const surface = document.createElement('div');
+  surface.className = 'listening__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'listening__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'listening__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const playButton = document.createElement('button');
+  playButton.type = 'button';
+  playButton.className = 'listening__play';
+  playButton.textContent = config.playLabel || 'Play audio';
+  surface.appendChild(playButton);
+
+  const answerGroup = document.createElement('div');
+  answerGroup.className = 'listening__answer';
+  surface.appendChild(answerGroup);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'listening__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'listening__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  return {
+    wrapper,
+    playButton,
+    answerGroup,
+    feedback,
+  };
+}
+
+function renderMultipleChoice(state, config) {
+  const answers = new Set(config.answers.map(normaliseAnswer));
+  const buttons = config.choices.map((choice) =>
+    createChoiceButton({
+      label: choice,
+      value: choice,
+      className: 'listening__choice',
+      onClick: (value, button) => {
+        if (state.completed) return;
+        const normalised = normaliseAnswer(value);
+        if (answers.has(normalised)) {
+          state.completed = true;
+          setStatusMessage(state.feedback, config.successMessage, 'success');
+          buttons.forEach((btn) => {
+            btn.disabled = true;
+            if (btn !== button) {
+              btn.classList.add('listening__choice--disabled');
+            }
+          });
+          button.classList.add('listening__choice--correct');
+          if (typeof state.onComplete === 'function') {
+            state.onComplete({ value, mode: 'choice' });
+          }
+        } else {
+          button.classList.add('listening__choice--incorrect');
+          setStatusMessage(state.feedback, config.errorMessage, 'error');
+        }
+      },
+    })
+  );
+
+  buttons.forEach((button) => state.answerGroup.appendChild(button));
+  state.buttons = buttons;
+}
+
+function renderTyping(state, config) {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'listening__input';
+  input.placeholder = config.placeholder || 'Type what you hear';
+  state.answerGroup.appendChild(input);
+
+  const submit = document.createElement('button');
+  submit.type = 'button';
+  submit.className = 'listening__submit';
+  submit.textContent = config.submitLabel || 'Check';
+  state.answerGroup.appendChild(submit);
+
+  submit.addEventListener('click', () => {
+    if (state.completed) return;
+    const attempt = normaliseAnswer(input.value);
+    const answers = config.answers.map(normaliseAnswer);
+    if (answers.includes(attempt)) {
+      state.completed = true;
+      input.disabled = true;
+      submit.disabled = true;
+      setStatusMessage(state.feedback, config.successMessage, 'success');
+      if (typeof state.onComplete === 'function') {
+        state.onComplete({ value: input.value, mode: 'typing' });
+      }
+    } else {
+      setStatusMessage(state.feedback, config.errorMessage, 'error');
+    }
+  });
+
+  state.input = input;
+  state.submit = submit;
+}
+
+export async function initListeningExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('Listening requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('Listening target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, playButton, answerGroup, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const audio = createAudio(config.audioSrc);
+  if (audio) {
+    playButton.addEventListener('click', () => {
+      audio.currentTime = 0;
+      audio.play();
+    });
+  } else {
+    playButton.disabled = true;
+    playButton.textContent = config.playFallback || 'Audio unavailable';
+  }
+
+  const state = {
+    answerGroup,
+    feedback,
+    onComplete,
+    completed: false,
+    buttons: [],
+  };
+
+  if (Array.isArray(config.choices) && config.choices.length) {
+    renderMultipleChoice(state, config);
+  } else {
+    renderTyping(state, config);
+  }
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return state;
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.Listening = initListeningExercise;
+}
+
+export default initListeningExercise;

--- a/src/exercises/Listening/styles.css
+++ b/src/exercises/Listening/styles.css
@@ -1,0 +1,185 @@
+.listening {
+  --exercise-bg: #184b35;
+  --exercise-surface: #0f3624;
+  --exercise-text: #f5fffa;
+  --exercise-muted: rgba(245, 255, 250, 0.7);
+  --exercise-accent: #1dd1a1;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top left, rgba(29, 209, 161, 0.2), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.listening__surface {
+  width: min(560px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.listening__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.listening__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.listening__play {
+  align-self: flex-start;
+  border: none;
+  border-radius: 16px;
+  padding: 0.75rem 1.5rem;
+  background: var(--exercise-accent);
+  color: #02211a;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.listening__play:hover,
+.listening__play:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(29, 209, 161, 0.25);
+  outline: none;
+}
+
+.listening__answer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.listening__choice {
+  border-radius: 18px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+  padding: 0.85rem 1rem;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.listening__choice:hover,
+.listening__choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(29, 209, 161, 0.8);
+  outline: none;
+}
+
+.listening__choice--correct {
+  border-color: rgba(147, 255, 210, 0.95);
+  background: rgba(29, 209, 161, 0.25);
+  color: #03241a;
+}
+
+.listening__choice--incorrect {
+  border-color: rgba(255, 122, 122, 0.9);
+  background: rgba(255, 122, 122, 0.18);
+}
+
+.listening__choice--disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.listening__input {
+  width: 100%;
+  border-radius: 16px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 1.05rem;
+  padding: 0.85rem 1rem;
+  font-family: inherit;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.listening__input:focus-visible {
+  outline: none;
+  border-color: rgba(29, 209, 161, 0.8);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.listening__submit {
+  align-self: flex-end;
+  border: none;
+  border-radius: 16px;
+  padding: 0.75rem 1.5rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--exercise-text);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.listening__submit:hover,
+.listening__submit:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.2);
+  outline: none;
+}
+
+.listening__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.listening__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.listening__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.listening__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.listening__instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--exercise-muted);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .listening {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .listening__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .listening__answer {
+    gap: 0.65rem;
+  }
+}

--- a/src/exercises/MatchPairs/config.json
+++ b/src/exercises/MatchPairs/config.json
@@ -1,0 +1,14 @@
+{
+  "id": "match-pairs-1",
+  "prompt": "Match the Sinhala words to their English meanings",
+  "instructions": "Tap two cards to see if they match.",
+  "pairs": [
+    { "base": "water", "target": "ජලය" },
+    { "base": "bread", "target": "පන්" },
+    { "base": "girl", "target": "ගැහැණු ළමයා" },
+    { "base": "school", "target": "පාසල" }
+  ],
+  "successMessage": "Nice! Keep matching the pairs.",
+  "errorMessage": "Those don't match yet.",
+  "initialMessage": "Remember each pair contains one English and one Sinhala word."
+}

--- a/src/exercises/MatchPairs/index.js
+++ b/src/exercises/MatchPairs/index.js
@@ -1,0 +1,163 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  shuffle,
+  setStatusMessage,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="match-pairs"]';
+const STYLESHEET_ID = 'match-pairs-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'match-pairs';
+
+  const surface = document.createElement('div');
+  surface.className = 'match-pairs__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'match-pairs__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'match-pairs__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'match-pairs__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  const grid = document.createElement('div');
+  grid.className = 'match-pairs__grid';
+  surface.appendChild(grid);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'match-pairs__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  return {
+    wrapper,
+    grid,
+    feedback,
+  };
+}
+
+function createCard(content, matchId, type) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'match-pairs__card';
+  button.dataset.matchId = String(matchId);
+  button.dataset.cardType = type;
+
+  const label = document.createElement('span');
+  label.className = 'match-pairs__card-label';
+  label.textContent = content;
+  button.appendChild(label);
+
+  return button;
+}
+
+export async function initMatchPairsExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('MatchPairs requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('MatchPairs target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, grid, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const cards = [];
+  config.pairs.forEach((pair, index) => {
+    cards.push(createCard(pair.base, index, 'base'));
+    cards.push(createCard(pair.target, index, 'target'));
+  });
+
+  shuffle(cards).forEach((card) => grid.appendChild(card));
+
+  let first = null;
+  let locked = false;
+  let matched = 0;
+  const totalMatches = config.pairs.length;
+
+  cards.forEach((card) => {
+    card.addEventListener('click', () => {
+      if (locked || card.classList.contains('match-pairs__card--matched')) {
+        return;
+      }
+
+      if (!first) {
+        first = card;
+        card.classList.add('match-pairs__card--selected');
+        return;
+      }
+
+      if (card === first) {
+        card.classList.remove('match-pairs__card--selected');
+        first = null;
+        return;
+      }
+
+      locked = true;
+      const match = card.dataset.matchId === first.dataset.matchId;
+      if (match && card.dataset.cardType !== first.dataset.cardType) {
+        card.classList.add('match-pairs__card--matched');
+        first.classList.add('match-pairs__card--matched');
+        card.disabled = true;
+        first.disabled = true;
+        matched += 1;
+        setStatusMessage(feedback, config.successMessage, 'success');
+        if (matched === totalMatches && typeof onComplete === 'function') {
+          onComplete({});
+        }
+        window.setTimeout(() => {
+          card.classList.remove('match-pairs__card--selected');
+          first?.classList.remove('match-pairs__card--selected');
+          first = null;
+          locked = false;
+        }, 350);
+      } else {
+        card.classList.add('match-pairs__card--wrong');
+        setStatusMessage(feedback, config.errorMessage, 'error');
+        window.setTimeout(() => {
+          card.classList.remove('match-pairs__card--wrong');
+          card.classList.remove('match-pairs__card--selected');
+          first?.classList.remove('match-pairs__card--selected');
+          first = null;
+          locked = false;
+        }, 650);
+      }
+    });
+  });
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return {
+    cards,
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.MatchPairs = initMatchPairsExercise;
+}
+
+export default initMatchPairsExercise;

--- a/src/exercises/MatchPairs/styles.css
+++ b/src/exercises/MatchPairs/styles.css
@@ -1,0 +1,131 @@
+.match-pairs {
+  --exercise-bg: #15354f;
+  --exercise-surface: #0c2334;
+  --exercise-text: #f5fffa;
+  --exercise-muted: rgba(245, 255, 250, 0.7);
+  --exercise-accent: #58d68d;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at bottom right, rgba(88, 214, 141, 0.2), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.match-pairs__surface {
+  width: min(720px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.8rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.match-pairs__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.match-pairs__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.match-pairs__instructions {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--exercise-muted);
+}
+
+.match-pairs__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.9rem;
+}
+
+.match-pairs__card {
+  border-radius: 18px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+  padding: 1rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+}
+
+.match-pairs__card:hover,
+.match-pairs__card:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(88, 214, 141, 0.8);
+  outline: none;
+}
+
+.match-pairs__card--selected {
+  border-color: rgba(88, 214, 141, 0.9);
+  background: rgba(88, 214, 141, 0.18);
+}
+
+.match-pairs__card--matched {
+  border-color: rgba(147, 255, 210, 0.95);
+  background: rgba(147, 255, 210, 0.25);
+  color: #09231d;
+  cursor: default;
+}
+
+.match-pairs__card--wrong {
+  border-color: rgba(255, 122, 122, 0.9);
+  background: rgba(255, 122, 122, 0.18);
+}
+
+.match-pairs__card-label {
+  display: block;
+}
+
+.match-pairs__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.match-pairs__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.match-pairs__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.match-pairs__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+@media (max-width: 640px) {
+  .match-pairs {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .match-pairs__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .match-pairs__grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}

--- a/src/exercises/PictureChoice/config.json
+++ b/src/exercises/PictureChoice/config.json
@@ -1,0 +1,29 @@
+{
+  "id": "picture-choice-1",
+  "prompt": "Which one is ‘බල්ලා’?",
+  "instructions": "Tap the picture that matches the Sinhala word.",
+  "choices": [
+    {
+      "label": "Dog",
+      "value": "dog",
+      "image": "/dog.svg",
+      "alt": "Illustration of a happy dog"
+    },
+    {
+      "label": "Cat",
+      "value": "cat",
+      "image": "/girl.svg",
+      "alt": "Illustration of a smiling girl"
+    },
+    {
+      "label": "Bird",
+      "value": "bird",
+      "image": "/robot.svg",
+      "alt": "Illustration of a friendly robot"
+    }
+  ],
+  "answers": ["dog"],
+  "successMessage": "Correct! ‘බල්ලා’ means dog.",
+  "errorMessage": "Try another picture.",
+  "initialMessage": "Look for the animal that matches the Sinhala word."
+}

--- a/src/exercises/PictureChoice/index.js
+++ b/src/exercises/PictureChoice/index.js
@@ -1,0 +1,137 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  createChoiceButton,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="picture-choice"]';
+const STYLESHEET_ID = 'picture-choice-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'picture-choice';
+
+  const surface = document.createElement('div');
+  surface.className = 'picture-choice__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'picture-choice__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'picture-choice__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const choices = document.createElement('div');
+  choices.className = 'picture-choice__choices';
+  surface.appendChild(choices);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'picture-choice__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'picture-choice__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  return {
+    wrapper,
+    choices,
+    feedback,
+  };
+}
+
+function createPictureButton(option, onClick) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'picture-choice__option';
+  button.addEventListener('click', () => onClick(option, button));
+
+  const image = document.createElement('img');
+  image.className = 'picture-choice__image';
+  image.src = option.image;
+  image.alt = option.alt || option.label || '';
+  button.appendChild(image);
+
+  const label = document.createElement('span');
+  label.className = 'picture-choice__label';
+  label.textContent = option.label;
+  button.appendChild(label);
+
+  return button;
+}
+
+export async function initPictureChoiceExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('PictureChoice requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('PictureChoice target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, choices, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const answers = new Set(config.answers.map(normaliseAnswer));
+  const buttons = [];
+  let completed = false;
+
+  config.choices.forEach((choice) => {
+    const button = createPictureButton(choice, (option, element) => {
+      if (completed) return;
+      const normalised = normaliseAnswer(option.value || option.label);
+      if (answers.has(normalised)) {
+        completed = true;
+        element.classList.add('picture-choice__option--correct');
+        buttons.forEach((btn) => {
+          btn.disabled = true;
+          if (btn !== element) {
+            btn.classList.add('picture-choice__option--disabled');
+          }
+        });
+        setStatusMessage(feedback, config.successMessage, 'success');
+        if (typeof onComplete === 'function') {
+          onComplete({ value: option });
+        }
+      } else {
+        element.classList.add('picture-choice__option--incorrect');
+        setStatusMessage(feedback, config.errorMessage, 'error');
+      }
+    });
+
+    choices.appendChild(button);
+    buttons.push(button);
+  });
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return {
+    buttons,
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.PictureChoice = initPictureChoiceExercise;
+}
+
+export default initPictureChoiceExercise;

--- a/src/exercises/PictureChoice/styles.css
+++ b/src/exercises/PictureChoice/styles.css
@@ -1,0 +1,141 @@
+.picture-choice {
+  --exercise-bg: #402b5a;
+  --exercise-surface: #2b1d40;
+  --exercise-text: #fdf8ff;
+  --exercise-muted: rgba(253, 248, 255, 0.7);
+  --exercise-accent: #b388ff;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top right, rgba(179, 136, 255, 0.18), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.picture-choice__surface {
+  width: min(680px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.35);
+  padding: clamp(1.75rem, 3vw, 2.9rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.picture-choice__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.picture-choice__prompt {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.picture-choice__choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.picture-choice__option {
+  border-radius: 18px;
+  overflow: hidden;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.picture-choice__option:hover,
+.picture-choice__option:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(179, 136, 255, 0.65);
+  box-shadow: 0 18px 28px rgba(0, 0, 0, 0.25);
+  outline: none;
+}
+
+.picture-choice__option--correct {
+  border-color: rgba(197, 225, 165, 0.95);
+  box-shadow: 0 18px 32px rgba(197, 225, 165, 0.25);
+}
+
+.picture-choice__option--incorrect {
+  border-color: rgba(255, 122, 122, 0.9);
+}
+
+.picture-choice__option--disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.picture-choice__image {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.picture-choice__label {
+  display: block;
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.picture-choice__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.picture-choice__feedback[data-status='success'] {
+  color: rgba(197, 225, 165, 0.95);
+}
+
+.picture-choice__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.picture-choice__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.picture-choice__instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--exercise-muted);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .picture-choice {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .picture-choice__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .picture-choice__choices {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/exercises/Speak/config.json
+++ b/src/exercises/Speak/config.json
@@ -1,0 +1,13 @@
+{
+  "id": "speak-1",
+  "prompt": "Say “සුභ උදෑසනක්”",
+  "transliteration": "subha udǣsanak",
+  "instructions": "Tap start and say the phrase clearly into your microphone.",
+  "answers": ["සුභ උදෑසනක්"],
+  "lang": "si-LK",
+  "successMessage": "Beautiful pronunciation!",
+  "errorMessage": "We didn't catch the phrase. Try again.",
+  "initialMessage": "Allow microphone access if prompted.",
+  "listeningMessage": "Listening…",
+  "retryLabel": "Try again"
+}

--- a/src/exercises/Speak/index.js
+++ b/src/exercises/Speak/index.js
@@ -1,0 +1,170 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  supportsSpeechRecognition,
+  createSpeechRecognizer,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="speak"]';
+const STYLESHEET_ID = 'speak-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'speak';
+
+  const surface = document.createElement('div');
+  surface.className = 'speak__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'speak__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'speak__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  if (config.transliteration) {
+    const transliteration = document.createElement('p');
+    transliteration.className = 'speak__transliteration';
+    transliteration.textContent = config.transliteration;
+    surface.appendChild(transliteration);
+  }
+
+  const instructions = document.createElement('p');
+  instructions.className = 'speak__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'speak__button';
+  button.textContent = config.startLabel || 'Start speaking';
+  surface.appendChild(button);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'speak__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const transcript = document.createElement('p');
+  transcript.className = 'speak__transcript';
+  transcript.textContent = '';
+  surface.appendChild(transcript);
+
+  return {
+    wrapper,
+    button,
+    feedback,
+    transcript,
+  };
+}
+
+export async function initSpeakExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('Speak exercises require a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('Speak target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, button, feedback, transcript } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const supported = supportsSpeechRecognition();
+  if (!supported) {
+    button.disabled = true;
+    button.textContent = config.unsupportedLabel || 'Speech recognition not supported in this browser';
+    setStatusMessage(feedback, config.unsupportedMessage || 'Try this exercise on a device with microphone access.', 'error');
+    return { supported: false };
+  }
+
+  const answers = config.answers.map(normaliseAnswer);
+  const recognizer = createSpeechRecognizer({ lang: config.lang || 'si-LK', maxAlternatives: 5 });
+  let listening = false;
+  let completed = false;
+
+  recognizer.addEventListener('result', (event) => {
+    if (!event.results) return;
+    const transcripts = [];
+    for (let i = 0; i < event.results.length; i += 1) {
+      const result = event.results[i];
+      for (let j = 0; j < result.length; j += 1) {
+        transcripts.push(result[j].transcript);
+      }
+    }
+
+    const combined = transcripts.join(' / ');
+    transcript.textContent = combined;
+    const normalised = transcripts.map(normaliseAnswer);
+    if (normalised.some((value) => answers.includes(value))) {
+      completed = true;
+      setStatusMessage(feedback, config.successMessage, 'success');
+      button.disabled = true;
+      recognizer.stop();
+      if (typeof onComplete === 'function') {
+        onComplete({ transcripts });
+      }
+    } else {
+      setStatusMessage(feedback, config.errorMessage, 'error');
+    }
+  });
+
+  recognizer.addEventListener('end', () => {
+    listening = false;
+    if (!completed) {
+      button.disabled = false;
+      button.textContent = config.retryLabel || 'Try again';
+    }
+  });
+
+  recognizer.addEventListener('error', (event) => {
+    listening = false;
+    button.disabled = false;
+    setStatusMessage(feedback, `${config.errorMessage || 'Something went wrong.'} (${event.error})`, 'error');
+  });
+
+  button.addEventListener('click', () => {
+    if (listening || completed) return;
+    transcript.textContent = '';
+    setStatusMessage(feedback, config.listeningMessage || 'Listening…', 'neutral');
+    button.disabled = true;
+    listening = true;
+    try {
+      recognizer.start();
+    } catch (error) {
+      listening = false;
+      button.disabled = false;
+      setStatusMessage(feedback, config.errorMessage || 'Unable to start recording.', 'error');
+    }
+  });
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return {
+    recognizer,
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.Speak = initSpeakExercise;
+}
+
+export default initSpeakExercise;

--- a/src/exercises/Speak/styles.css
+++ b/src/exercises/Speak/styles.css
@@ -1,0 +1,108 @@
+.speak {
+  --exercise-bg: #2b3550;
+  --exercise-surface: #1a2034;
+  --exercise-text: #f5f7ff;
+  --exercise-muted: rgba(245, 247, 255, 0.72);
+  --exercise-accent: #4c6ef5;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top left, rgba(76, 110, 245, 0.18), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.speak__surface {
+  width: min(520px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+  align-items: center;
+  text-align: center;
+}
+
+.speak__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.speak__transliteration {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--exercise-muted);
+}
+
+.speak__instructions {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--exercise-muted);
+}
+
+.speak__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 2.4rem;
+  background: var(--exercise-accent);
+  color: #0a1024;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.speak__button:hover,
+.speak__button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 24px rgba(76, 110, 245, 0.25);
+  outline: none;
+}
+
+.speak__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+}
+
+.speak__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.speak__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.speak__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.speak__transcript {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(245, 247, 255, 0.85);
+  min-height: 1.5em;
+}
+
+@media (max-width: 640px) {
+  .speak {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .speak__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+}

--- a/src/exercises/TranslateToBase/config.json
+++ b/src/exercises/TranslateToBase/config.json
@@ -1,0 +1,17 @@
+{
+  "id": "translate-to-base-1",
+  "badge": "NEW WORD",
+  "prompt": "මම",
+  "transliteration": "mama",
+  "choices": [
+    { "label": "I" },
+    { "label": "You" },
+    { "label": "We" },
+    { "label": "They" }
+  ],
+  "answers": ["I"],
+  "instructions": "Select the English meaning that matches the Sinhala word.",
+  "successMessage": "Correct! 'මම' means 'I'.",
+  "errorMessage": "Not quite, try again.",
+  "initialMessage": "Tap the correct English meaning from the list."
+}

--- a/src/exercises/TranslateToBase/index.js
+++ b/src/exercises/TranslateToBase/index.js
@@ -1,0 +1,135 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  createChoiceButton,
+  formatBadge,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="translate-to-base"]';
+const STYLESHEET_ID = 'translate-to-base-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'translate-to-base';
+
+  const surface = document.createElement('div');
+  surface.className = 'translate-to-base__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'translate-to-base__header';
+  surface.appendChild(header);
+
+  const badge = document.createElement('span');
+  badge.className = 'translate-to-base__badge';
+  badge.textContent = formatBadge(config.badge || 'NEW WORD');
+  header.appendChild(badge);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'translate-to-base__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  if (config.transliteration) {
+    const transliteration = document.createElement('p');
+    transliteration.className = 'translate-to-base__transliteration';
+    transliteration.textContent = config.transliteration;
+    header.appendChild(transliteration);
+  }
+
+  const choicesContainer = document.createElement('div');
+  choicesContainer.className = 'translate-to-base__choices';
+  surface.appendChild(choicesContainer);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'translate-to-base__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'translate-to-base__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  return {
+    wrapper,
+    choicesContainer,
+    feedback,
+  };
+}
+
+export async function initTranslateToBaseExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('TranslateToBase requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('TranslateToBase target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, choicesContainer, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const answers = new Set(config.answers.map(normaliseAnswer));
+
+  const state = {
+    completed: false,
+  };
+
+  const buttons = config.choices.map((choice) =>
+    createChoiceButton({
+      label: choice.label,
+      value: choice.value ?? choice.label,
+      className: 'translate-to-base__choice',
+      onClick: (value, button) => {
+        if (state.completed) return;
+        const normalised = normaliseAnswer(value);
+        if (answers.has(normalised)) {
+          state.completed = true;
+          setStatusMessage(feedback, config.successMessage, 'success');
+          button.classList.add('translate-to-base__choice--correct');
+          buttons.forEach((btn) => {
+            btn.disabled = true;
+            if (btn !== button) {
+              btn.classList.add('translate-to-base__choice--disabled');
+            }
+          });
+          if (typeof onComplete === 'function') {
+            onComplete({ value });
+          }
+        } else {
+          button.classList.add('translate-to-base__choice--incorrect');
+          setStatusMessage(feedback, config.errorMessage, 'error');
+        }
+      },
+    })
+  );
+
+  buttons.forEach((button) => choicesContainer.appendChild(button));
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return {
+    buttons,
+    config,
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.TranslateToBase = initTranslateToBaseExercise;
+}
+
+export default initTranslateToBaseExercise;

--- a/src/exercises/TranslateToBase/styles.css
+++ b/src/exercises/TranslateToBase/styles.css
@@ -1,0 +1,145 @@
+.translate-to-base {
+  --exercise-bg: #00534e;
+  --exercise-surface: #003d39;
+  --exercise-text: #f5fffa;
+  --exercise-muted: rgba(245, 255, 250, 0.64);
+  --exercise-accent: #0bcb88;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3.25rem) clamp(1rem, 4vw, 3rem);
+  background: var(--exercise-bg);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.translate-to-base__surface {
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.28);
+  width: min(560px, 100%);
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.translate-to-base__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.translate-to-base__badge {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  background: rgba(11, 203, 136, 0.18);
+  color: var(--exercise-accent);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+}
+
+.translate-to-base__prompt {
+  margin: 0;
+  font-size: clamp(2.1rem, 6vw, 2.9rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.translate-to-base__transliteration {
+  margin: 0;
+  font-size: clamp(1rem, 3.2vw, 1.15rem);
+  color: var(--exercise-muted);
+}
+
+.translate-to-base__choices {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.translate-to-base__choice {
+  border: 2px solid transparent;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  text-align: center;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  cursor: pointer;
+}
+
+.translate-to-base__choice:hover,
+.translate-to-base__choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(11, 203, 136, 0.8);
+  outline: none;
+}
+
+.translate-to-base__choice--correct {
+  border-color: rgba(147, 255, 210, 0.95);
+  background: rgba(11, 203, 136, 0.25);
+  color: #ffffff;
+}
+
+.translate-to-base__choice--incorrect {
+  border-color: rgba(255, 122, 122, 0.9);
+  background: rgba(255, 122, 122, 0.18);
+}
+
+.translate-to-base__choice--disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.translate-to-base__feedback {
+  margin: 0.5rem 0 0;
+  font-size: 1rem;
+  min-height: 1.5em;
+  font-weight: 600;
+  text-align: center;
+}
+
+.translate-to-base__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.translate-to-base__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.translate-to-base__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.translate-to-base__instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  text-align: center;
+  color: var(--exercise-muted);
+}
+
+@media (max-width: 600px) {
+  .translate-to-base {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .translate-to-base__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+
+  .translate-to-base__choices {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/exercises/TranslateToTarget/config.json
+++ b/src/exercises/TranslateToTarget/config.json
@@ -1,0 +1,13 @@
+{
+  "id": "translate-to-target-1",
+  "mode": "multiple-choice",
+  "badge": "TRANSLATE",
+  "prompt": "Translate to Sinhala",
+  "source": "The girl drinks tea.",
+  "choices": ["ගැහැණු ළමයා තේ බොයි.", "ගැහැනු ළමයා කන්න යයි.", "බාලයා නින්ද යයි.", "අයියා පාඩම් කරයි."],
+  "answers": ["ගැහැණු ළමයා තේ බොයි."],
+  "instructions": "Tap the Sinhala translation that matches the English sentence.",
+  "successMessage": "Great! You chose the correct Sinhala translation.",
+  "errorMessage": "Not quite. Try another option.",
+  "initialMessage": "Focus on the verb and subject order when you translate."
+}

--- a/src/exercises/TranslateToTarget/index.js
+++ b/src/exercises/TranslateToTarget/index.js
@@ -1,0 +1,190 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  setStatusMessage,
+  createChoiceButton,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="translate-to-target"]';
+const STYLESHEET_ID = 'translate-to-target-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'translate-to-target';
+
+  const surface = document.createElement('div');
+  surface.className = 'translate-to-target__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'translate-to-target__header';
+  surface.appendChild(header);
+
+  const badge = document.createElement('span');
+  badge.className = 'translate-to-target__badge';
+  badge.textContent = config.badge || 'TRANSLATE';
+  header.appendChild(badge);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'translate-to-target__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const source = document.createElement('p');
+  source.className = 'translate-to-target__source';
+  source.textContent = config.source;
+  surface.appendChild(source);
+
+  const answerGroup = document.createElement('div');
+  answerGroup.className = 'translate-to-target__answer';
+  surface.appendChild(answerGroup);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'translate-to-target__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  const footer = document.createElement('footer');
+  footer.className = 'translate-to-target__footer';
+  surface.appendChild(footer);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'translate-to-target__instructions';
+  instructions.textContent = config.instructions;
+  footer.appendChild(instructions);
+
+  return {
+    wrapper,
+    answerGroup,
+    feedback,
+  };
+}
+
+function renderMultipleChoice(state, config) {
+  const { answerGroup } = state;
+  answerGroup.innerHTML = '';
+  answerGroup.classList.add('translate-to-target__choices');
+
+  const answers = new Set(config.answers.map(normaliseAnswer));
+
+  const buttons = config.choices.map((choice) =>
+    createChoiceButton({
+      label: choice,
+      value: choice,
+      className: 'translate-to-target__choice',
+      onClick: (value, button) => {
+        if (state.completed) return;
+        const normalised = normaliseAnswer(value);
+        if (answers.has(normalised)) {
+          state.completed = true;
+          setStatusMessage(state.feedback, config.successMessage, 'success');
+          button.classList.add('translate-to-target__choice--correct');
+          state.buttons.forEach((btn) => {
+            if (btn !== button) {
+              btn.disabled = true;
+              btn.classList.add('translate-to-target__choice--disabled');
+            }
+          });
+          if (typeof state.onComplete === 'function') {
+            state.onComplete({ value, mode: 'choice' });
+          }
+        } else {
+          button.classList.add('translate-to-target__choice--incorrect');
+          setStatusMessage(state.feedback, config.errorMessage, 'error');
+        }
+      },
+    })
+  );
+
+  buttons.forEach((button) => answerGroup.appendChild(button));
+  state.buttons = buttons;
+}
+
+function renderTyping(state, config) {
+  const { answerGroup } = state;
+  answerGroup.innerHTML = '';
+  answerGroup.classList.remove('translate-to-target__choices');
+
+  const input = document.createElement('textarea');
+  input.className = 'translate-to-target__input';
+  input.rows = 3;
+  input.placeholder = config.placeholder || 'Type your translation';
+  answerGroup.appendChild(input);
+
+  const submit = document.createElement('button');
+  submit.type = 'button';
+  submit.className = 'translate-to-target__submit';
+  submit.textContent = config.submitLabel || 'Check';
+  answerGroup.appendChild(submit);
+
+  submit.addEventListener('click', () => {
+    if (state.completed) return;
+    const value = input.value;
+    const normalised = normaliseAnswer(value);
+    const answers = config.answers.map(normaliseAnswer);
+    if (answers.includes(normalised)) {
+      state.completed = true;
+      input.disabled = true;
+      submit.disabled = true;
+      setStatusMessage(state.feedback, config.successMessage, 'success');
+      if (typeof state.onComplete === 'function') {
+        state.onComplete({ value, mode: 'typing' });
+      }
+    } else {
+      setStatusMessage(state.feedback, config.errorMessage, 'error');
+    }
+  });
+
+  state.input = input;
+  state.submit = submit;
+}
+
+export async function initTranslateToTargetExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('TranslateToTarget requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('TranslateToTarget target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, answerGroup, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const state = {
+    answerGroup,
+    feedback,
+    onComplete,
+    completed: false,
+    buttons: [],
+  };
+
+  if (config.mode === 'multiple-choice') {
+    renderMultipleChoice(state, config);
+  } else {
+    renderTyping(state, config);
+  }
+
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  return state;
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.TranslateToTarget = initTranslateToTargetExercise;
+}
+
+export default initTranslateToTargetExercise;

--- a/src/exercises/TranslateToTarget/styles.css
+++ b/src/exercises/TranslateToTarget/styles.css
@@ -1,0 +1,195 @@
+.translate-to-target {
+  --exercise-bg: #0b4f4a;
+  --exercise-surface: #043733;
+  --exercise-border: rgba(255, 255, 255, 0.1);
+  --exercise-text: #f5fffa;
+  --exercise-muted: rgba(245, 255, 250, 0.7);
+  --exercise-accent: #0bcb88;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.translate-to-target__surface {
+  width: min(640px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid var(--exercise-border);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.28);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2.5vw, 2.25rem);
+}
+
+.translate-to-target__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.translate-to-target__badge {
+  background: rgba(11, 203, 136, 0.15);
+  color: var(--exercise-accent);
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.translate-to-target__prompt {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.translate-to-target__source {
+  margin: 0;
+  font-size: clamp(1.15rem, 3vw, 1.35rem);
+  font-weight: 600;
+}
+
+.translate-to-target__answer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.translate-to-target__choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.85rem;
+}
+
+.translate-to-target__choice {
+  border-radius: 18px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 1.05rem;
+  padding: 0.8rem 1rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.translate-to-target__choice:hover,
+.translate-to-target__choice:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(11, 203, 136, 0.8);
+  outline: none;
+}
+
+.translate-to-target__choice--correct {
+  border-color: rgba(147, 255, 210, 0.95);
+  background: rgba(11, 203, 136, 0.25);
+  color: #ffffff;
+}
+
+.translate-to-target__choice--incorrect {
+  border-color: rgba(255, 122, 122, 0.9);
+  background: rgba(255, 122, 122, 0.18);
+}
+
+.translate-to-target__choice--disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.translate-to-target__input {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  border-radius: 16px;
+  border: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 1.05rem;
+  padding: 0.9rem 1rem;
+  font-family: inherit;
+  line-height: 1.5;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.translate-to-target__input:focus-visible {
+  outline: none;
+  border-color: rgba(11, 203, 136, 0.8);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.translate-to-target__submit {
+  align-self: flex-end;
+  border: none;
+  border-radius: 16px;
+  padding: 0.75rem 1.5rem;
+  background: var(--exercise-accent);
+  color: #012b28;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.translate-to-target__submit:hover,
+.translate-to-target__submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(11, 203, 136, 0.25);
+  outline: none;
+}
+
+.translate-to-target__feedback {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  min-height: 1.5em;
+  text-align: center;
+}
+
+.translate-to-target__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.translate-to-target__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.translate-to-target__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+.translate-to-target__footer {
+  display: flex;
+  justify-content: center;
+}
+
+.translate-to-target__instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--exercise-muted);
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .translate-to-target {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .translate-to-target__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .translate-to-target__choices {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/exercises/WordBank/config.json
+++ b/src/exercises/WordBank/config.json
@@ -1,0 +1,10 @@
+{
+  "id": "word-bank-1",
+  "prompt": "Build the sentence in Sinhala",
+  "instructions": "Tap the tiles to build the sentence in the correct order.",
+  "wordBank": ["මම", "ටී", "බොමි", "ඒක", "දින"],
+  "answers": ["මම ටී බොමි"],
+  "successMessage": "Great work! You built the sentence correctly.",
+  "errorMessage": "Check the word order and try again.",
+  "initialMessage": "Hint: Sinhala sentences often end with the verb."
+}

--- a/src/exercises/WordBank/index.js
+++ b/src/exercises/WordBank/index.js
@@ -1,0 +1,189 @@
+import {
+  ensureStylesheet,
+  loadConfig,
+  normaliseAnswer,
+  shuffle,
+  setStatusMessage,
+  createTile,
+} from '../_shared/utils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="word-bank"]';
+const STYLESHEET_ID = 'word-bank-styles';
+
+function buildLayout(config) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'word-bank';
+
+  const surface = document.createElement('div');
+  surface.className = 'word-bank__surface';
+  wrapper.appendChild(surface);
+
+  const header = document.createElement('header');
+  header.className = 'word-bank__header';
+  surface.appendChild(header);
+
+  const prompt = document.createElement('h2');
+  prompt.className = 'word-bank__prompt';
+  prompt.textContent = config.prompt;
+  header.appendChild(prompt);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'word-bank__instructions';
+  instructions.textContent = config.instructions;
+  surface.appendChild(instructions);
+
+  const assembled = document.createElement('div');
+  assembled.className = 'word-bank__assembled';
+  assembled.setAttribute('role', 'list');
+  surface.appendChild(assembled);
+
+  const bank = document.createElement('div');
+  bank.className = 'word-bank__bank';
+  bank.setAttribute('role', 'list');
+  surface.appendChild(bank);
+
+  const footer = document.createElement('footer');
+  footer.className = 'word-bank__footer';
+  surface.appendChild(footer);
+
+  const check = document.createElement('button');
+  check.type = 'button';
+  check.className = 'word-bank__check';
+  check.textContent = config.submitLabel || 'Check';
+  footer.appendChild(check);
+
+  const clear = document.createElement('button');
+  clear.type = 'button';
+  clear.className = 'word-bank__reset';
+  clear.textContent = config.resetLabel || 'Reset';
+  footer.appendChild(clear);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'word-bank__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  surface.appendChild(feedback);
+
+  return {
+    wrapper,
+    assembled,
+    bank,
+    check,
+    clear,
+    feedback,
+  };
+}
+
+function renderTiles(state) {
+  const { config, bank, assembledTiles, bankTiles } = state;
+
+  bank.innerHTML = '';
+  assembledTiles.innerHTML = '';
+
+  state.availableTiles.forEach((word) => {
+    const tile = createTile(word);
+    tile.addEventListener('click', () => {
+      if (tile.disabled || state.completed) return;
+      tile.disabled = true;
+      tile.classList.add('word-bank__tile--used');
+      state.selection.push(word);
+      updateAssembled(state);
+    });
+    bank.appendChild(tile);
+    bankTiles.push(tile);
+  });
+}
+
+function updateAssembled(state) {
+  const { assembledTiles, selection } = state;
+  assembledTiles.innerHTML = '';
+  selection.forEach((word, index) => {
+    const tile = createTile(word);
+    tile.classList.add('word-bank__tile--assembled');
+    tile.addEventListener('click', () => {
+      if (state.completed) return;
+      state.selection.splice(index, 1);
+      const original = state.bankTiles.find((btn) => btn.dataset.tileValue === word);
+      if (original) {
+        original.disabled = false;
+        original.classList.remove('word-bank__tile--used');
+      }
+      updateAssembled(state);
+    });
+    assembledTiles.appendChild(tile);
+  });
+}
+
+export async function initWordBankExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('WordBank requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    config: configOverride,
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('WordBank target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css');
+  const config = await loadConfig({ config: configOverride });
+  const { wrapper, assembled, bank, check, clear, feedback } = buildLayout(config);
+  target.innerHTML = '';
+  target.appendChild(wrapper);
+
+  const state = {
+    config,
+    assembledTiles: assembled,
+    bank,
+    bankTiles: [],
+    selection: [],
+    availableTiles: shuffle(config.wordBank || []),
+    feedback,
+    completed: false,
+  };
+
+  renderTiles(state);
+  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+
+  check.addEventListener('click', () => {
+    if (state.completed) return;
+    const attempt = normaliseAnswer(state.selection.join(' '));
+    const answers = (config.answers || []).map(normaliseAnswer);
+    if (answers.includes(attempt)) {
+      state.completed = true;
+      setStatusMessage(feedback, config.successMessage, 'success');
+      check.disabled = true;
+      clear.disabled = true;
+      if (typeof onComplete === 'function') {
+        onComplete({ value: state.selection.slice() });
+      }
+    } else {
+      setStatusMessage(feedback, config.errorMessage, 'error');
+    }
+  });
+
+  clear.addEventListener('click', () => {
+    if (state.completed) return;
+    state.selection = [];
+    state.bankTiles.forEach((tile) => {
+      tile.disabled = false;
+      tile.classList.remove('word-bank__tile--used');
+    });
+    updateAssembled(state);
+    setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+  });
+
+  return state;
+}
+
+if (typeof window !== 'undefined') {
+  window.BashaLanka = window.BashaLanka || {};
+  window.BashaLanka.exercises = window.BashaLanka.exercises || {};
+  window.BashaLanka.exercises.WordBank = initWordBankExercise;
+}
+
+export default initWordBankExercise;

--- a/src/exercises/WordBank/styles.css
+++ b/src/exercises/WordBank/styles.css
@@ -1,0 +1,179 @@
+.word-bank {
+  --exercise-bg: #0b3f57;
+  --exercise-surface: #052b3b;
+  --exercise-text: #f5fffa;
+  --exercise-muted: rgba(245, 255, 250, 0.7);
+  --exercise-accent: #4dd0e1;
+  --exercise-danger: #ff7a7a;
+  width: 100%;
+  min-height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top left, rgba(77, 208, 225, 0.15), transparent 45%),
+    var(--exercise-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.word-bank__surface {
+  width: min(720px, 100%);
+  background: var(--exercise-surface);
+  color: var(--exercise-text);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
+  padding: clamp(1.75rem, 3vw, 2.9rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+.word-bank__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.word-bank__prompt {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.word-bank__instructions {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--exercise-muted);
+}
+
+.word-bank__assembled,
+.word-bank__bank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  min-height: 56px;
+}
+
+.word-bank__assembled {
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+}
+
+.word-bank__bank {
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+}
+
+.word-bank__tile,
+.word-bank__tile--assembled,
+.word-bank__tile--used {
+  border: none;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  font-weight: 600;
+  padding: 0.55rem 0.95rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+}
+
+.word-bank__tile:hover,
+.word-bank__tile:focus-visible,
+.word-bank__tile--assembled:hover,
+.word-bank__tile--assembled:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(77, 208, 225, 0.22);
+  outline: none;
+}
+
+.word-bank__tile--used {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.word-bank__footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.word-bank__check,
+.word-bank__reset {
+  border-radius: 16px;
+  border: none;
+  padding: 0.7rem 1.6rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.word-bank__check {
+  background: var(--exercise-accent);
+  color: #03252f;
+}
+
+.word-bank__reset {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--exercise-text);
+}
+
+.word-bank__check:hover,
+.word-bank__check:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 18px rgba(77, 208, 225, 0.25);
+  outline: none;
+}
+
+.word-bank__reset:hover,
+.word-bank__reset:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.2);
+  outline: none;
+}
+
+.word-bank__feedback {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  min-height: 1.5em;
+}
+
+.word-bank__feedback[data-status='success'] {
+  color: rgba(147, 255, 210, 0.95);
+}
+
+.word-bank__feedback[data-status='error'] {
+  color: var(--exercise-danger);
+}
+
+.word-bank__feedback[data-status='neutral'] {
+  color: var(--exercise-muted);
+}
+
+@media (max-width: 640px) {
+  .word-bank {
+    padding: 1.5rem 1.25rem 2.25rem;
+  }
+
+  .word-bank__surface {
+    border-radius: 20px;
+    padding: 1.5rem;
+  }
+
+  .word-bank__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .word-bank__check,
+  .word-bank__reset {
+    width: 100%;
+  }
+}

--- a/src/exercises/_shared/utils.js
+++ b/src/exercises/_shared/utils.js
@@ -1,0 +1,168 @@
+const DEFAULT_FETCH_OPTIONS = {
+  credentials: 'same-origin',
+  headers: {
+    Accept: 'application/json',
+  },
+};
+
+export function ensureStylesheet(id, relativeHref) {
+  if (typeof document === 'undefined') return;
+  if (!id || !relativeHref) return;
+
+  if (document.getElementById(id)) {
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.id = id;
+  link.rel = 'stylesheet';
+
+  try {
+    link.href = new URL(relativeHref, import.meta.url);
+  } catch (error) {
+    console.error('Unable to resolve stylesheet URL', { id, relativeHref, error });
+    return;
+  }
+
+  document.head.appendChild(link);
+}
+
+export function normaliseAnswer(value) {
+  return (value || '')
+    .toString()
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+export function shuffle(array) {
+  const items = Array.isArray(array) ? array.slice() : [];
+  for (let i = items.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+  return items;
+}
+
+export function createAudio(src) {
+  if (typeof Audio === 'undefined' || !src) {
+    return null;
+  }
+
+  const audio = new Audio();
+  audio.src = src;
+  return audio;
+}
+
+export async function loadConfig(options = {}) {
+  const { config, fallbackPath = './config.json' } = options;
+
+  if (config && typeof config === 'object') {
+    return config;
+  }
+
+  let path = config;
+
+  if (!path) {
+    path = fallbackPath;
+  }
+
+  if (typeof path !== 'string') {
+    throw new Error('Exercise configuration must be an object or JSON path.');
+  }
+
+  if (typeof fetch === 'undefined') {
+    throw new Error('Fetching exercise configuration requires a browser environment.');
+  }
+
+  const response = await fetch(new URL(path, import.meta.url), DEFAULT_FETCH_OPTIONS);
+  if (!response.ok) {
+    throw new Error(`Failed to load configuration file: ${path}`);
+  }
+
+  return response.json();
+}
+
+export function setStatusMessage(element, message, variant = 'neutral') {
+  if (!element) return;
+  element.textContent = message || '';
+  element.setAttribute('data-status', variant);
+}
+
+export function announce(element, message) {
+  if (!element || typeof document === 'undefined') return;
+  const liveRegion = document.createElement('div');
+  liveRegion.setAttribute('role', 'status');
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.className = 'sr-only';
+  liveRegion.textContent = message;
+  document.body.appendChild(liveRegion);
+  window.setTimeout(() => {
+    document.body.removeChild(liveRegion);
+  }, 750);
+}
+
+export function toggleBusy(element, busy) {
+  if (!element) return;
+  if (busy) {
+    element.setAttribute('aria-busy', 'true');
+  } else {
+    element.removeAttribute('aria-busy');
+  }
+}
+
+export function formatBadge(text) {
+  if (!text) return '';
+  return String(text).toUpperCase();
+}
+
+export function createChoiceButton({ label, value, onClick, className }) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className || 'exercise__choice';
+  button.textContent = label;
+  if (value !== undefined) {
+    button.value = value;
+  }
+  if (typeof onClick === 'function') {
+    button.addEventListener('click', () => onClick(value, button));
+  }
+  return button;
+}
+
+export function createTile(text) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'exercise__tile';
+  button.textContent = text;
+  button.dataset.tileValue = text;
+  return button;
+}
+
+export function supportsSpeechRecognition() {
+  if (typeof window === 'undefined') return false;
+  return (
+    'SpeechRecognition' in window ||
+    'webkitSpeechRecognition' in window ||
+    'mozSpeechRecognition' in window ||
+    'msSpeechRecognition' in window
+  );
+}
+
+export function createSpeechRecognizer(options = {}) {
+  if (!supportsSpeechRecognition()) {
+    return null;
+  }
+
+  const Constructor =
+    window.SpeechRecognition ||
+    window.webkitSpeechRecognition ||
+    window.mozSpeechRecognition ||
+    window.msSpeechRecognition;
+
+  const recognizer = new Constructor();
+  recognizer.lang = options.lang || 'si-LK';
+  recognizer.interimResults = Boolean(options.interimResults);
+  recognizer.maxAlternatives = options.maxAlternatives || 3;
+  return recognizer;
+}


### PR DESCRIPTION
## Summary
- add dialogue, fill-in-the-blank, listening, match-pairs, picture choice, speaking, translation, and word bank exercise modules
- provide shared utilities for loading configs, styling, and interaction helpers
- supply corresponding JSON configs and tailored styles for each exercise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61ab5f8208330b3a61d2b0ca106bd