### PR TITLE
feat: refresh TranslateToBase layout with mascot and speech bubble

### DIFF
--- a/assets/Lessons/exercises/TranslateToBase/index.js
+++ b/assets/Lessons/exercises/TranslateToBase/index.js
@@ -460,7 +460,7 @@ function buildLayout(config) {
   surface.className = 'translate-to-base__surface';
   wrapper.appendChild(surface);
 
-  const header = document.createElement('header');
+  const header = document.createElement('div');
   header.className = 'translate-to-base__header';
   surface.appendChild(header);
 
@@ -469,18 +469,70 @@ function buildLayout(config) {
   badge.textContent = formatBadge(config.badge || 'NEW WORD');
   header.appendChild(badge);
 
+  const headerMain = document.createElement('div');
+  headerMain.className = 'translate-to-base__header-main';
+  header.appendChild(headerMain);
 
-  const prompt = document.createElement('h2');
-  prompt.className = 'translate-to-base__prompt';
+  const lessonContext = window.BashaLanka?.currentLesson || {};
+  const lessonDetail = lessonContext.detail || {};
+  const lessonMeta = lessonContext.meta || {};
+  let mascotSrc = lessonDetail.mascot;
+  if (!mascotSrc && lessonMeta.sectionNumber) {
+    mascotSrc = `assets/sections/section-${lessonMeta.sectionNumber}/mascot.svg`;
+  }
+  if (!mascotSrc) {
+    mascotSrc = 'assets/sections/section-1/mascot.svg';
+  }
+  const mascot = document.createElement('img');
+  mascot.className = 'translate-to-base__mascot';
+  mascot.src = mascotSrc;
+  mascot.alt = 'Lesson mascot';
+  headerMain.appendChild(mascot);
+
+  const bubble = document.createElement('div');
+  bubble.className = 'translate-to-base__bubble';
+  headerMain.appendChild(bubble);
+
+  const prompt = document.createElement('span');
+  prompt.className = 'translate-to-base__prompt-si';
   prompt.textContent = config.prompt;
-  header.appendChild(prompt);
+  bubble.appendChild(prompt);
+
+  const soundButton = document.createElement('button');
+  soundButton.type = 'button';
+  soundButton.className = 'translate-to-base__sound';
+  soundButton.setAttribute('aria-label', `Play pronunciation for ${config.prompt}`);
+  const soundIcon = document.createElement('img');
+  soundIcon.className = 'translate-to-base__sound-icon';
+  soundIcon.src = 'assets/general/Sound_out_1.svg';
+  soundIcon.alt = '';
+  soundIcon.setAttribute('aria-hidden', 'true');
+  soundButton.appendChild(soundIcon);
 
   if (config.transliteration) {
-    const transliteration = document.createElement('p');
-    transliteration.className = 'translate-to-base__transliteration';
+    const transliteration = document.createElement('span');
+    transliteration.className = 'translate-to-base__prompt-translit';
     transliteration.textContent = config.transliteration;
-    header.appendChild(transliteration);
+    bubble.appendChild(transliteration);
   }
+
+  bubble.appendChild(soundButton);
+
+  soundButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (
+      typeof window === 'undefined' ||
+      typeof window.speechSynthesis === 'undefined' ||
+      typeof window.SpeechSynthesisUtterance !== 'function'
+    ) {
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+    const utter = new window.SpeechSynthesisUtterance(config.prompt);
+    utter.lang = 'si-LK';
+    window.speechSynthesis.speak(utter);
+  });
 
   const choicesContainer = document.createElement('div');
   choicesContainer.className = 'translate-to-base__choices';

--- a/assets/Lessons/exercises/TranslateToBase/styles.css
+++ b/assets/Lessons/exercises/TranslateToBase/styles.css
@@ -32,8 +32,15 @@
 .translate-to-base__header {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.6rem;
+  align-items: stretch;
+  gap: clamp(0.75rem, 2vw, 1.15rem);
+}
+
+.translate-to-base__header-main {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.4rem);
+  width: 100%;
 }
 
 .translate-to-base__badge {
@@ -46,17 +53,83 @@
   padding: 0.35rem 0.9rem;
 }
 
-.translate-to-base__prompt {
-  margin: 0;
-  font-size: clamp(2.1rem, 6vw, 2.9rem);
-  font-weight: 700;
-  letter-spacing: 0.02em;
+.translate-to-base__mascot {
+  width: clamp(56px, 10vw, 72px);
+  height: clamp(56px, 10vw, 72px);
+  object-fit: contain;
+  flex-shrink: 0;
 }
 
-.translate-to-base__transliteration {
+.translate-to-base__bubble {
+  position: relative;
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: clamp(0.85rem, 2.5vw, 1.35rem) clamp(1rem, 3vw, 1.75rem);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18);
+}
+
+.translate-to-base__bubble::after {
+  content: '';
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18);
+}
+
+.translate-to-base__prompt-si {
+  display: block;
+  text-align: center;
+  font-size: clamp(2.1rem, 6vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
   margin: 0;
-  font-size: clamp(1rem, 3.2vw, 1.15rem);
+}
+
+.translate-to-base__prompt-translit {
+  display: block;
+  margin-top: 0.35rem;
+  text-align: center;
+  font-size: clamp(0.95rem, 3vw, 1.1rem);
   color: var(--exercise-muted);
+}
+
+.translate-to-base__sound {
+  position: absolute;
+  top: clamp(0.5rem, 1.5vw, 0.75rem);
+  right: clamp(0.5rem, 1.5vw, 0.75rem);
+  display: grid;
+  place-items: center;
+  width: clamp(2.25rem, 6vw, 2.75rem);
+  height: clamp(2.25rem, 6vw, 2.75rem);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background: rgba(11, 203, 136, 0.18);
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.translate-to-base__sound:hover,
+.translate-to-base__sound:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(11, 203, 136, 0.8);
+  outline: none;
+  background: rgba(11, 203, 136, 0.28);
+}
+
+.translate-to-base__sound:active {
+  transform: translateY(1px);
+}
+
+.translate-to-base__sound-icon {
+  width: clamp(1.1rem, 3.2vw, 1.35rem);
+  height: auto;
+  filter: brightness(1.2);
 }
 
 .translate-to-base__choices {


### PR DESCRIPTION
## Summary
- restructure the TranslateToBase exercise header to include the mascot, Sinhala prompt, transliteration, and a new sound button inside a speech bubble
- add styling to deliver a Duolingo-inspired layout while retaining existing choice/feedback behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ab5b73648330bcff85fab4cd0b57