### PR TITLE
style: center TranslateToBase prompt and align sound icon

### DIFF
--- a/assets/Lessons/exercises/TranslateToBase/index.js
+++ b/assets/Lessons/exercises/TranslateToBase/index.js
@@ -460,7 +460,7 @@ function buildLayout(config) {
   surface.className = 'translate-to-base__surface';
   wrapper.appendChild(surface);
 
-  const header = document.createElement('header');
+  const header = document.createElement('div');
   header.className = 'translate-to-base__header';
   surface.appendChild(header);
 
@@ -469,18 +469,74 @@ function buildLayout(config) {
   badge.textContent = formatBadge(config.badge || 'NEW WORD');
   header.appendChild(badge);
 
+  const headerMain = document.createElement('div');
+  headerMain.className = 'translate-to-base__header-main';
+  header.appendChild(headerMain);
 
-  const prompt = document.createElement('h2');
-  prompt.className = 'translate-to-base__prompt';
+  const lessonContext = window.BashaLanka?.currentLesson || {};
+  const lessonDetail = lessonContext.detail || {};
+  const lessonMeta = lessonContext.meta || {};
+  let mascotSrc = lessonDetail.mascot;
+  if (!mascotSrc && lessonMeta.sectionNumber) {
+    mascotSrc = `assets/sections/section-${lessonMeta.sectionNumber}/mascot.svg`;
+  }
+  if (!mascotSrc) {
+    mascotSrc = 'assets/sections/section-1/mascot.svg';
+  }
+  const mascot = document.createElement('img');
+  mascot.className = 'translate-to-base__mascot';
+  mascot.src = mascotSrc;
+  mascot.alt = 'Lesson mascot';
+  headerMain.appendChild(mascot);
+
+  const bubble = document.createElement('div');
+  bubble.className = 'translate-to-base__bubble';
+  headerMain.appendChild(bubble);
+
+  const soundButton = document.createElement('button');
+  soundButton.type = 'button';
+  soundButton.className = 'translate-to-base__sound';
+  soundButton.setAttribute('aria-label', `Play pronunciation for ${config.prompt}`);
+  const soundIcon = document.createElement('img');
+  soundIcon.className = 'translate-to-base__sound-icon';
+  soundIcon.src = 'assets/general/Sound_out_1.svg';
+  soundIcon.alt = '';
+  soundIcon.setAttribute('aria-hidden', 'true');
+  soundButton.appendChild(soundIcon);
+
+  const promptRow = document.createElement('div');
+  promptRow.className = 'translate-to-base__prompt-row';
+  bubble.appendChild(promptRow);
+
+  const prompt = document.createElement('span');
+  prompt.className = 'translate-to-base__prompt-si';
   prompt.textContent = config.prompt;
-  header.appendChild(prompt);
+  promptRow.appendChild(prompt);
+
+  promptRow.appendChild(soundButton);
 
   if (config.transliteration) {
-    const transliteration = document.createElement('p');
-    transliteration.className = 'translate-to-base__transliteration';
+    const transliteration = document.createElement('span');
+    transliteration.className = 'translate-to-base__prompt-translit';
     transliteration.textContent = config.transliteration;
-    header.appendChild(transliteration);
+    bubble.appendChild(transliteration);
   }
+
+  soundButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    if (
+      typeof window === 'undefined' ||
+      typeof window.speechSynthesis === 'undefined' ||
+      typeof window.SpeechSynthesisUtterance !== 'function'
+    ) {
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+    const utter = new window.SpeechSynthesisUtterance(config.prompt);
+    utter.lang = 'si-LK';
+    window.speechSynthesis.speak(utter);
+  });
 
   const choicesContainer = document.createElement('div');
   choicesContainer.className = 'translate-to-base__choices';

--- a/assets/Lessons/exercises/TranslateToBase/styles.css
+++ b/assets/Lessons/exercises/TranslateToBase/styles.css
@@ -32,8 +32,15 @@
 .translate-to-base__header {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.6rem;
+  align-items: stretch;
+  gap: clamp(0.75rem, 2vw, 1.15rem);
+}
+
+.translate-to-base__header-main {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.4rem);
+  width: 100%;
 }
 
 .translate-to-base__badge {
@@ -46,17 +53,97 @@
   padding: 0.35rem 0.9rem;
 }
 
-.translate-to-base__prompt {
-  margin: 0;
-  font-size: clamp(2.1rem, 6vw, 2.9rem);
-  font-weight: 700;
-  letter-spacing: 0.02em;
+.translate-to-base__mascot {
+  width: clamp(56px, 10vw, 72px);
+  height: clamp(56px, 10vw, 72px);
+  object-fit: contain;
+  flex-shrink: 0;
 }
 
-.translate-to-base__transliteration {
+.translate-to-base__bubble {
+  position: relative;
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: clamp(0.85rem, 2.5vw, 1.35rem) clamp(1rem, 3vw, 1.75rem);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.5rem, 2vw, 0.85rem);
+}
+
+.translate-to-base__bubble::after {
+  content: '';
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18);
+}
+
+.translate-to-base__prompt-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  column-gap: clamp(0.5rem, 1.5vw, 0.85rem);
+}
+
+.translate-to-base__prompt-si {
+  grid-column: 1 / span 2;
+  justify-self: center;
+  display: block;
+  text-align: center;
+  font-size: clamp(1.575rem, 4.5vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
   margin: 0;
-  font-size: clamp(1rem, 3.2vw, 1.15rem);
+}
+
+.translate-to-base__prompt-translit {
+  display: block;
+  margin-top: 0.35rem;
+  text-align: center;
+  font-size: clamp(0.95rem, 3vw, 1.1rem);
   color: var(--exercise-muted);
+}
+
+.translate-to-base__sound {
+  grid-column: 2;
+  align-self: center;
+  background: none;
+  border: none;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.18s ease;
+}
+
+.translate-to-base__sound:focus-visible {
+  outline: 2px solid rgba(11, 203, 136, 0.8);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.translate-to-base__sound:hover {
+  transform: translateY(-1px);
+}
+
+.translate-to-base__sound:active {
+  transform: translateY(1px);
+}
+
+.translate-to-base__sound-icon {
+  width: clamp(1.35rem, 3.5vw, 1.85rem);
+  height: auto;
+  display: block;
 }
 
 .translate-to-base__choices {


### PR DESCRIPTION
## Summary
- center the Sinhala prompt within the TranslateToBase speech bubble while keeping the sound button on the right
- let the sound control render the Sound_out_1.svg asset directly without the circular background styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ab5b73648330bcff85fab4cd0b57