### PR TITLE
Simplify MatchPairs init to always use lesson vocab

### DIFF
--- a/assets/Lessons/exercises/MatchPairs/styles.css
+++ b/assets/Lessons/exercises/MatchPairs/styles.css
@@ -3,12 +3,15 @@
   --exercise-surface: #0c2334;
   --exercise-text: #f5fffa;
   --exercise-muted: rgba(245, 255, 250, 0.7);
-  --exercise-accent: #58d68d;
+  --exercise-accent: #0bcb88;
+  --exercise-accent-soft: rgba(11, 203, 136, 0.2);
+  --exercise-accent-strong: rgba(11, 203, 136, 0.95);
+  --exercise-success: rgba(147, 255, 210, 0.95);
   --exercise-danger: #ff7a7a;
   width: 100%;
   min-height: 100%;
   padding: clamp(1.5rem, 4vw, 3rem);
-  background: radial-gradient(circle at bottom right, rgba(88, 214, 141, 0.2), transparent 45%),
+  background: radial-gradient(circle at bottom right, rgba(11, 203, 136, 0.16), transparent 45%),
     var(--exercise-bg);
   display: flex;
   align-items: center;
@@ -18,7 +21,7 @@
 }
 
 .match-pairs__surface {
-  width: min(720px, 100%);
+  width: min(760px, 100%);
   background: var(--exercise-surface);
   color: var(--exercise-text);
   border-radius: 24px;
@@ -51,38 +54,46 @@
 
 .match-pairs__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 1.5rem;
+  align-items: start;
+}
+
+.match-pairs__column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .match-pairs__card {
-  border-radius: 18px;
-  border: 2px solid transparent;
-  background: rgba(255, 255, 255, 0.08);
-  color: inherit;
-  font-weight: 600;
-  font-size: 1.05rem;
-  padding: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
   cursor: pointer;
-  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  text-align: center;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #fff;
 }
 
 .match-pairs__card:hover,
 .match-pairs__card:focus-visible {
   transform: translateY(-2px);
-  border-color: rgba(88, 214, 141, 0.8);
+  border-color: rgba(11, 203, 136, 0.8);
   outline: none;
 }
 
 .match-pairs__card--selected {
-  border-color: rgba(88, 214, 141, 0.9);
-  background: rgba(88, 214, 141, 0.18);
+  border-color: var(--exercise-accent-strong);
+  background: var(--exercise-accent-soft);
 }
 
 .match-pairs__card--matched {
-  border-color: rgba(147, 255, 210, 0.95);
-  background: rgba(147, 255, 210, 0.25);
-  color: #09231d;
+  border-color: var(--exercise-success);
+  background: rgba(11, 203, 136, 0.25);
   cursor: default;
 }
 
@@ -95,8 +106,21 @@
   display: block;
 }
 
+.match-pairs__card-script {
+  display: block;
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.match-pairs__card-translit {
+  display: block;
+  font-size: 0.9rem;
+  color: rgba(245, 255, 250, 0.65);
+}
+
 .match-pairs__feedback {
-  margin: 0;
+  margin: 0.5rem 0 0;
   font-weight: 600;
   font-size: 1rem;
   min-height: 1.5em;
@@ -104,7 +128,7 @@
 }
 
 .match-pairs__feedback[data-status='success'] {
-  color: rgba(147, 255, 210, 0.95);
+  color: var(--exercise-success);
 }
 
 .match-pairs__feedback[data-status='error'] {
@@ -115,17 +139,33 @@
   color: var(--exercise-muted);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .match-pairs {
     padding: 1.5rem 1.25rem 2.25rem;
   }
 
   .match-pairs__surface {
     border-radius: 20px;
-    padding: 1.5rem;
+    padding: 1.75rem 1.25rem 2rem;
   }
 
   .match-pairs__grid {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.85rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .match-pairs__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .match-pairs__column {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .match-pairs__card {
+    flex: 1 1 calc(50% - 0.75rem);
   }
 }

--- a/assets/Lessons/exercises/TranslateToBase/index.js
+++ b/assets/Lessons/exercises/TranslateToBase/index.js
@@ -191,7 +191,7 @@ function resolveManifestEntry(manifest, context = {}) {
   return candidates[0] || null;
 }
 
-async function fetchLessonVocab() {
+export async function fetchLessonVocab() {
   if (typeof window === 'undefined') {
     throw new Error('TranslateToBase requires a browser environment.');
   }


### PR DESCRIPTION
## Summary
- load MatchPairs vocab exclusively from the active lesson using the existing fetchLessonVocab helper and ensure only five pairs are used
- render dynamically generated Sinhala and English cards with transliteration, updated messaging, and Duolingo-style feedback states
- refresh MatchPairs styling for the two-column layout and export fetchLessonVocab for reuse by other exercises
- randomize the selected lesson vocab pairs so each exercise run shuffles the five-card set

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da6448c3b88330aefdacda691d07cb