### PR TITLE
Refactor WordBank to load lesson vocab dynamically

### DIFF
--- a/assets/Lessons/exercises/WordBank/index.js
+++ b/assets/Lessons/exercises/WordBank/index.js
@@ -1,16 +1,294 @@
 import {
   ensureStylesheet,
-  loadConfig,
   normaliseAnswer,
   normaliseText,
-  createAnswerLookup,
   shuffle,
   setStatusMessage,
   createTile,
 } from '../_shared/utils.js';
+import { fetchLessonVocab, fetchAllLessonVocabsUpTo, loadLessonSource } from '../TranslateToBase/index.js';
 
 const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="word-bank"]';
 const STYLESHEET_ID = 'word-bank-styles';
+const MIN_TILE_COUNT = 6;
+const MAX_TILE_COUNT = 10;
+
+function tokenizeSentence(sentence) {
+  if (!sentence) return [];
+  return sentence
+    .toString()
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function buildAnswerTileList(answers) {
+  const counts = new Map();
+  answers.forEach((answer) => {
+    const tokens = tokenizeSentence(answer);
+    const local = new Map();
+    tokens.forEach((token) => {
+      local.set(token, (local.get(token) || 0) + 1);
+    });
+    local.forEach((value, token) => {
+      const current = counts.get(token) || 0;
+      if (value > current) {
+        counts.set(token, value);
+      }
+    });
+  });
+
+  const tiles = [];
+  counts.forEach((count, token) => {
+    for (let i = 0; i < count; i += 1) {
+      tiles.push(token);
+    }
+  });
+  return tiles;
+}
+
+function stripPunctuation(word) {
+  if (!word) return '';
+  return word
+    .toString()
+    .trim()
+    .replace(/^[“”"'`]+/, '')
+    .replace(/[.,!?;:"”'`]+$/g, '')
+    .trim();
+}
+
+function collectDistractorWords(vocabEntries) {
+  const unique = new Map();
+  (Array.isArray(vocabEntries) ? vocabEntries : []).forEach((entry) => {
+    if (!entry || typeof entry !== 'object') return;
+    const english = normaliseText(entry.en || entry.english || '');
+    if (!english) return;
+    english
+      .split(/\s+/)
+      .map(stripPunctuation)
+      .filter(Boolean)
+      .forEach((word) => {
+        const key = word.toLowerCase();
+        if (!unique.has(key)) {
+          unique.set(key, word);
+        }
+      });
+  });
+  return Array.from(unique.values());
+}
+
+function parseAnswersFromValue(value) {
+  const answers = [];
+
+  const add = (item) => {
+    const text = normaliseText(item);
+    if (text) {
+      answers.push(text);
+    }
+  };
+
+  const parseCandidate = (candidate) => {
+    if (!candidate && candidate !== 0) return;
+    if (Array.isArray(candidate)) {
+      candidate.forEach(parseCandidate);
+      return;
+    }
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (!trimmed) return;
+      if ((trimmed.startsWith('[') && trimmed.endsWith(']')) || (trimmed.startsWith('{') && trimmed.endsWith('}'))) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          parseCandidate(parsed);
+          return;
+        } catch (error) {
+          // Fall back to splitting below if JSON.parse fails.
+        }
+      }
+      trimmed
+        .split(/\s*\|\s*|\s*\/\s*|\s*;\s*/)
+        .filter(Boolean)
+        .forEach(add);
+      return;
+    }
+    if (typeof candidate === 'object') {
+      Object.values(candidate || {}).forEach(parseCandidate);
+      return;
+    }
+    add(candidate);
+  };
+
+  parseCandidate(value);
+  return Array.from(new Set(answers));
+}
+
+function normaliseWordBankEntry(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const answer = normaliseText(raw);
+    if (!answer) return null;
+    return {
+      prompt: 'Build the sentence',
+      instructions: 'Tap the words in the correct order.',
+      placeholder: 'Tap the tiles to build the sentence.',
+      answers: [answer],
+    };
+  }
+
+  if (typeof raw !== 'object') return null;
+
+  const answerSources = [
+    raw.answers,
+    raw.answer,
+    raw.accept,
+    raw.correct,
+    raw.sentence,
+    raw.sentences,
+    raw.solution,
+    raw.expected,
+    raw.expectedAnswer,
+    raw.target,
+    raw.output,
+    raw.text,
+  ];
+
+  const answers = answerSources.flatMap((candidate) => parseAnswersFromValue(candidate));
+
+  if (!answers.length) return null;
+
+  const prompt = normaliseText(
+    raw.prompt || raw.title || raw.question || raw.label || raw.translation || 'Build the sentence'
+  );
+  const instructions = normaliseText(
+    raw.instructions || raw.instruction || raw.subtitle || 'Tap the words in the correct order.'
+  );
+  const placeholder = normaliseText(
+    raw.placeholder || raw.placeholderText || raw.helper || 'Tap the tiles to build the sentence.'
+  );
+  const hint = normaliseText(raw.hint || raw.translation || raw.clue || '');
+  const successMessage = normaliseText(raw.successMessage || raw.success || 'Correct! Nice work.');
+  const errorMessage = normaliseText(raw.errorMessage || raw.error || 'Not quite, try again.');
+  const initialMessage = normaliseText(raw.initialMessage || raw.initial || 'Tap tiles to build the sentence.');
+
+  return {
+    prompt: prompt || 'Build the sentence',
+    instructions: instructions || 'Tap the words in the correct order.',
+    placeholder: placeholder || 'Tap the tiles to build the sentence.',
+    hint,
+    successMessage: successMessage || 'Correct! Nice work.',
+    errorMessage: errorMessage || 'Not quite, try again.',
+    initialMessage,
+    answers,
+  };
+}
+
+function normalisePromptList(value) {
+  const list = Array.isArray(value) ? value : value ? [value] : [];
+  return list
+    .map(normaliseWordBankEntry)
+    .filter((entry) => entry && Array.isArray(entry.answers) && entry.answers.length);
+}
+
+function parseLessonNumber(value) {
+  if (value === null || value === undefined) return null;
+  const number = Number.parseInt(value, 10);
+  if (Number.isFinite(number) && number > 0) return number;
+  const match = value.toString().match(/lesson[-_\s]?(\d+)/i);
+  if (!match) return null;
+  const parsed = Number.parseInt(match[1], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function resolveLessonNumber(context = {}) {
+  const meta = context.meta || {};
+  const detail = context.detail || {};
+  return (
+    parseLessonNumber(meta.lessonNumber) ||
+    parseLessonNumber(detail.lessonNumber) ||
+    parseLessonNumber(detail.lessonId) ||
+    parseLessonNumber(detail.lessonPath)
+  );
+}
+
+async function fetchWordBankPrompts() {
+  if (typeof window === 'undefined') {
+    throw new Error('WordBank requires a browser environment.');
+  }
+
+  const context = window.BashaLanka?.currentLesson || {};
+  const detail = context.detail || {};
+
+  const candidateSources = [detail.wordBankPrompts, detail.wordBank, detail.wordbank];
+  for (const source of candidateSources) {
+    const prompts = normalisePromptList(source);
+    if (prompts.length) {
+      return prompts;
+    }
+  }
+
+  let lessonPath = detail.lessonPath;
+  if (!lessonPath) {
+    const lessonNumber = resolveLessonNumber(context);
+    if (lessonNumber) {
+      lessonPath = `assets/Lessons/lesson-${String(lessonNumber).padStart(2, '0')}.md`;
+    }
+  }
+
+  if (!lessonPath) {
+    throw new Error('Lesson markdown path unavailable for WordBank exercise.');
+  }
+
+  const lesson = await loadLessonSource(lessonPath);
+  const prompts = normalisePromptList(lesson.wordBankPrompts || lesson.wordbank || lesson.wordBank);
+  if (!prompts.length) {
+    throw new Error('Lesson markdown is missing WordBank prompts.');
+  }
+  if (!detail.lessonPath) {
+    detail.lessonPath = lesson.path;
+  }
+  detail.wordBankPrompts = prompts;
+  return prompts;
+}
+
+function buildWordBankConfig(entry, options = {}) {
+  if (!entry || !Array.isArray(entry.answers) || !entry.answers.length) {
+    throw new Error('WordBank entry requires at least one answer.');
+  }
+
+  const baseTiles = buildAnswerTileList(entry.answers);
+  if (!baseTiles.length) {
+    throw new Error('WordBank answers must include at least one word.');
+  }
+  const baseSet = new Set(baseTiles.map((word) => word.toLowerCase()));
+  const distractorWords = Array.isArray(options.distractorWords) ? options.distractorWords : [];
+  const shuffledDistractors = shuffle(distractorWords).filter((word) => {
+    if (!word) return false;
+    const key = word.toLowerCase();
+    if (baseSet.has(key)) return false;
+    baseSet.add(key);
+    return true;
+  });
+
+  const words = baseTiles.slice();
+  const minTarget = baseTiles.length > MAX_TILE_COUNT ? baseTiles.length : Math.max(MIN_TILE_COUNT, baseTiles.length);
+  for (const word of shuffledDistractors) {
+    if (words.length >= minTarget) break;
+    if (words.length >= MAX_TILE_COUNT && baseTiles.length <= MAX_TILE_COUNT) break;
+    words.push(word);
+  }
+
+  return {
+    prompt: entry.prompt,
+    instructions: entry.instructions,
+    placeholder: entry.placeholder,
+    hint: entry.hint,
+    successMessage: entry.successMessage,
+    errorMessage: entry.errorMessage,
+    initialMessage: entry.initialMessage,
+    answers: entry.answers,
+    wordBank: words,
+  };
+}
 
 function buildLayout(config) {
   const wrapper = document.createElement('section');
@@ -24,41 +302,83 @@ function buildLayout(config) {
   header.className = 'word-bank__header';
   surface.appendChild(header);
 
-  const prompt = document.createElement('h2');
-  prompt.className = 'word-bank__prompt';
-  prompt.textContent = config.prompt;
-  header.appendChild(prompt);
+  const title = document.createElement('h2');
+  title.className = 'word-bank__title';
+  title.textContent = config.prompt || 'Build the sentence';
+  header.appendChild(title);
 
-  const instructions = document.createElement('p');
-  instructions.className = 'word-bank__instructions';
-  instructions.textContent = config.instructions;
-  surface.appendChild(instructions);
+  const hero = document.createElement('div');
+  hero.className = 'word-bank__hero';
+  surface.appendChild(hero);
+
+  const lessonContext = window.BashaLanka?.currentLesson || {};
+  const lessonDetail = lessonContext.detail || {};
+  const lessonMeta = lessonContext.meta || {};
+  let mascotSrc = lessonDetail.mascot;
+  if (!mascotSrc && lessonMeta.sectionNumber) {
+    mascotSrc = `assets/sections/section-${lessonMeta.sectionNumber}/mascot.svg`;
+  }
+  if (!mascotSrc) {
+    mascotSrc = 'assets/sections/section-1/mascot.svg';
+  }
+
+  const mascot = document.createElement('img');
+  mascot.className = 'word-bank__mascot';
+  mascot.src = mascotSrc;
+  mascot.alt = 'Lesson mascot';
+  hero.appendChild(mascot);
+
+  const bubble = document.createElement('div');
+  bubble.className = 'word-bank__bubble';
+  hero.appendChild(bubble);
+
+  const bubbleLabel = document.createElement('p');
+  bubbleLabel.className = 'word-bank__bubble-label';
+  bubbleLabel.textContent = 'Assemble the sentence';
+  bubble.appendChild(bubbleLabel);
 
   const assembled = document.createElement('div');
   assembled.className = 'word-bank__assembled';
   assembled.setAttribute('role', 'list');
-  surface.appendChild(assembled);
+  bubble.appendChild(assembled);
+
+  const placeholder = document.createElement('span');
+  placeholder.className = 'word-bank__assembled-placeholder';
+  placeholder.textContent = config.placeholder || 'Tap the tiles to build the sentence.';
+  assembled.appendChild(placeholder);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'word-bank__instructions';
+  instructions.textContent = config.instructions || 'Tap the words in the correct order.';
+  surface.appendChild(instructions);
+
+  if (config.hint) {
+    const hint = document.createElement('p');
+    hint.className = 'word-bank__hint';
+    hint.textContent = config.hint;
+    surface.appendChild(hint);
+  }
 
   const bank = document.createElement('div');
   bank.className = 'word-bank__bank';
   bank.setAttribute('role', 'list');
   surface.appendChild(bank);
 
-  const footer = document.createElement('footer');
-  footer.className = 'word-bank__footer';
-  surface.appendChild(footer);
+  const controls = document.createElement('div');
+  controls.className = 'word-bank__controls';
+  surface.appendChild(controls);
 
   const check = document.createElement('button');
   check.type = 'button';
-  check.className = 'word-bank__check';
-  check.textContent = config.submitLabel || 'Check';
-  footer.appendChild(check);
+  check.className = 'word-bank__button word-bank__button--check';
+  check.textContent = 'Check';
+  controls.appendChild(check);
 
-  const clear = document.createElement('button');
-  clear.type = 'button';
-  clear.className = 'word-bank__reset';
-  clear.textContent = config.resetLabel || 'Reset';
-  footer.appendChild(clear);
+  const reset = document.createElement('button');
+  reset.type = 'button';
+  reset.className = 'word-bank__button word-bank__button--reset';
+  reset.textContent = 'Reset';
+  controls.appendChild(reset);
 
   const feedback = document.createElement('p');
   feedback.className = 'word-bank__feedback';
@@ -68,97 +388,93 @@ function buildLayout(config) {
 
   return {
     wrapper,
+    surface,
     assembled,
+    assembledPlaceholder: placeholder,
     bank,
     check,
-    clear,
+    reset,
     feedback,
   };
 }
 
+function updateAssembledState(state) {
+  const tiles = Array.from(state.assembled.querySelectorAll('.word-bank__tile'));
+  state.selection = tiles.map((tile) => tile.dataset.tileValue || tile.textContent || '');
+  if (state.placeholder) {
+    state.placeholder.hidden = tiles.length > 0;
+  }
+  state.assembled.classList.toggle('word-bank__assembled--filled', tiles.length > 0);
+  state.assembled.classList.remove('word-bank__assembled--error');
+}
+
+function handleTileInteraction(state, tile) {
+  if (!tile || state.completed) return;
+  const parent = tile.parentElement;
+  if (parent === state.bank) {
+    state.assembled.appendChild(tile);
+    tile.classList.add('word-bank__tile--selected');
+  } else {
+    state.bank.appendChild(tile);
+    tile.classList.remove('word-bank__tile--selected');
+  }
+  updateAssembledState(state);
+}
+
 function renderTiles(state) {
-  const { config, bank, assembledTiles, bankTiles } = state;
-
-  bank.innerHTML = '';
-  assembledTiles.innerHTML = '';
-
-  state.availableTiles.forEach((word) => {
+  state.bank.innerHTML = '';
+  state.tiles = state.config.wordBank.map((word, index) => {
     const tile = createTile(word);
-    tile.addEventListener('click', () => {
-      if (tile.disabled || state.completed) return;
-      tile.disabled = true;
-      tile.classList.add('word-bank__tile--used');
-      state.selection.push(word);
-      updateAssembled(state);
-    });
-    bank.appendChild(tile);
-    bankTiles.push(tile);
+    tile.classList.add('word-bank__tile');
+    tile.dataset.tileKey = `${index}-${Math.random().toString(36).slice(2, 8)}`;
+    tile.addEventListener('click', () => handleTileInteraction(state, tile));
+    return tile;
+  });
+
+  shuffle(state.tiles.slice()).forEach((tile) => {
+    state.bank.appendChild(tile);
   });
 }
 
-function updateAssembled(state) {
-  const { assembledTiles, selection } = state;
-  assembledTiles.innerHTML = '';
-  selection.forEach((word, index) => {
-    const tile = createTile(word);
-    tile.classList.add('word-bank__tile--assembled');
-    tile.addEventListener('click', () => {
-      if (state.completed) return;
-      state.selection.splice(index, 1);
-      const original = state.bankTiles.find((btn) => btn.dataset.tileValue === word);
-      if (original) {
-        original.disabled = false;
-        original.classList.remove('word-bank__tile--used');
-      }
-      updateAssembled(state);
-    });
-    assembledTiles.appendChild(tile);
+function resetState(state) {
+  state.selection = [];
+  state.tiles.forEach((tile) => {
+    tile.disabled = false;
+    tile.classList.remove('word-bank__tile--selected', 'word-bank__tile--locked');
+    state.bank.appendChild(tile);
   });
+  state.completed = false;
+  state.check.disabled = false;
+  state.reset.disabled = false;
+  state.assembled.classList.remove('word-bank__assembled--correct', 'word-bank__assembled--error');
+  updateAssembledState(state);
 }
 
-function prepareConfig(rawConfig) {
-  if (!rawConfig || typeof rawConfig !== 'object') {
-    throw new Error('WordBank config must be an object.');
+function lockTiles(state) {
+  state.tiles.forEach((tile) => {
+    tile.disabled = true;
+    tile.classList.add('word-bank__tile--locked');
+  });
+  state.check.disabled = true;
+  state.reset.disabled = true;
+  state.assembled.classList.add('word-bank__assembled--correct');
+}
+
+async function prepareConfig() {
+  const vocab = await fetchLessonVocab();
+  const context = window.BashaLanka?.currentLesson || {};
+  const lessonNumber = resolveLessonNumber(context) || 1;
+  let allVocabs = await fetchAllLessonVocabsUpTo(lessonNumber);
+  if (!Array.isArray(allVocabs) || !allVocabs.length) {
+    allVocabs = vocab || [];
   }
-
-  const prompt = normaliseText(rawConfig.prompt);
-  if (!prompt) {
-    throw new Error('WordBank config requires a prompt.');
+  const prompts = await fetchWordBankPrompts();
+  if (!prompts.length) {
+    throw new Error('No WordBank prompts available for this lesson.');
   }
-
-  const instructions = normaliseText(rawConfig.instructions) || 'Arrange the tiles to complete the sentence.';
-
-  const rawTiles = Array.isArray(rawConfig.wordBank)
-    ? rawConfig.wordBank
-    : Array.isArray(rawConfig.choices)
-    ? rawConfig.choices
-    : [];
-
-  const tiles = rawTiles
-    .map((tile) => normaliseText(tile))
-    .filter(Boolean);
-
-  if (!tiles.length) {
-    throw new Error('WordBank config requires at least one tile.');
-  }
-
-  const answersLookup = createAnswerLookup(rawConfig.answers);
-  if (!answersLookup.size) {
-    throw new Error('WordBank config requires at least one correct answer.');
-  }
-
-  return {
-    ...rawConfig,
-    prompt,
-    instructions,
-    wordBank: tiles,
-    answers: Array.from(answersLookup.values()),
-    successMessage: normaliseText(rawConfig.successMessage) || 'Correct! Nice work.',
-    errorMessage: normaliseText(rawConfig.errorMessage) || 'Not quite, try again.',
-    initialMessage: normaliseText(rawConfig.initialMessage),
-    submitLabel: normaliseText(rawConfig.submitLabel) || 'Check',
-    resetLabel: normaliseText(rawConfig.resetLabel) || 'Reset',
-  };
+  const entry = prompts.length === 1 ? prompts[0] : prompts[Math.floor(Math.random() * prompts.length)];
+  const distractorWords = collectDistractorWords(allVocabs);
+  return buildWordBankConfig(entry, { distractorWords });
 }
 
 export async function initWordBankExercise(options = {}) {
@@ -177,52 +493,78 @@ export async function initWordBankExercise(options = {}) {
   }
 
   ensureStylesheet(STYLESHEET_ID, './styles.css', { baseUrl: import.meta.url });
-  const rawConfig = await loadConfig({ config: configOverride, baseUrl: import.meta.url });
-  const config = prepareConfig(rawConfig);
-  const { wrapper, assembled, bank, check, clear, feedback } = buildLayout(config);
+
+  let config;
+  if (configOverride && typeof configOverride === 'object') {
+    const entry = normaliseWordBankEntry(configOverride);
+    if (!entry) {
+      throw new Error('Invalid WordBank config override supplied.');
+    }
+    const manualDistractors = Array.isArray(configOverride.distractors)
+      ? configOverride.distractors
+      : Array.isArray(configOverride.distractorWords)
+      ? configOverride.distractorWords
+      : [];
+    config = buildWordBankConfig(entry, { distractorWords: manualDistractors });
+    if (Array.isArray(configOverride.wordBank) && configOverride.wordBank.length) {
+      const manualBank = configOverride.wordBank
+        .map((word) => normaliseText(word))
+        .filter(Boolean);
+      if (manualBank.length) {
+        config.wordBank = manualBank;
+      }
+    }
+  } else {
+    config = await prepareConfig();
+  }
+  const { wrapper, assembled, assembledPlaceholder, bank, check, reset, feedback } = buildLayout(config);
+
   target.innerHTML = '';
   target.appendChild(wrapper);
 
   const state = {
     config,
-    assembledTiles: assembled,
+    assembled,
+    placeholder: assembledPlaceholder,
     bank,
-    bankTiles: [],
-    selection: [],
-    availableTiles: shuffle(config.wordBank || []),
+    check,
+    reset,
     feedback,
+    tiles: [],
+    selection: [],
     completed: false,
+    normalisedAnswers: config.answers.map(normaliseAnswer),
   };
 
   renderTiles(state);
-  setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+  updateAssembledState(state);
+  setStatusMessage(feedback, config.initialMessage || 'Tap tiles to build the sentence.', 'neutral');
 
   check.addEventListener('click', () => {
     if (state.completed) return;
     const attempt = normaliseAnswer(state.selection.join(' '));
-    const answers = (config.answers || []).map(normaliseAnswer);
-    if (answers.includes(attempt)) {
+    if (!attempt) {
+      state.assembled.classList.add('word-bank__assembled--error');
+      setStatusMessage(state.feedback, 'Select tiles to form a sentence first.', 'neutral');
+      return;
+    }
+    if (state.normalisedAnswers.includes(attempt)) {
       state.completed = true;
-      setStatusMessage(feedback, config.successMessage, 'success');
-      check.disabled = true;
-      clear.disabled = true;
+      lockTiles(state);
+      setStatusMessage(state.feedback, config.successMessage || 'Correct! Nice work.', 'success');
       if (typeof onComplete === 'function') {
         onComplete({ value: state.selection.slice() });
       }
     } else {
-      setStatusMessage(feedback, config.errorMessage, 'error');
+      state.assembled.classList.add('word-bank__assembled--error');
+      setStatusMessage(state.feedback, config.errorMessage || 'Not quite, try again.', 'error');
     }
   });
 
-  clear.addEventListener('click', () => {
+  reset.addEventListener('click', () => {
     if (state.completed) return;
-    state.selection = [];
-    state.bankTiles.forEach((tile) => {
-      tile.disabled = false;
-      tile.classList.remove('word-bank__tile--used');
-    });
-    updateAssembled(state);
-    setStatusMessage(feedback, config.initialMessage || '', 'neutral');
+    resetState(state);
+    setStatusMessage(state.feedback, config.initialMessage || 'Tap tiles to build the sentence.', 'neutral');
   });
 
   return state;

--- a/assets/Lessons/exercises/WordBank/styles.css
+++ b/assets/Lessons/exercises/WordBank/styles.css
@@ -1,179 +1,296 @@
 .word-bank {
-  --exercise-bg: #0b3f57;
-  --exercise-surface: #052b3b;
-  --exercise-text: #f5fffa;
-  --exercise-muted: rgba(245, 255, 250, 0.7);
-  --exercise-accent: #4dd0e1;
-  --exercise-danger: #ff7a7a;
+  --word-bank-bg: #0a3c66;
+  --word-bank-surface: #f6f8fc;
+  --word-bank-text: #1f2a44;
+  --word-bank-muted: #5a6781;
+  --word-bank-accent: #1ec38b;
+  --word-bank-accent-dark: #13a16f;
+  --word-bank-danger: #e05666;
+  --word-bank-border: rgba(15, 36, 64, 0.08);
   width: 100%;
   min-height: 100%;
-  padding: clamp(1.5rem, 4vw, 3rem);
-  background: radial-gradient(circle at top left, rgba(77, 208, 225, 0.15), transparent 45%),
-    var(--exercise-bg);
+  padding: clamp(1.75rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3.25rem);
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 45%),
+    var(--word-bank-bg);
   display: flex;
-  align-items: center;
   justify-content: center;
+  align-items: center;
   box-sizing: border-box;
   font-family: 'Noto Sans Sinhala', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .word-bank__surface {
   width: min(720px, 100%);
-  background: var(--exercise-surface);
-  color: var(--exercise-text);
-  border-radius: 24px;
+  background: var(--word-bank-surface);
+  color: var(--word-bank-text);
+  border-radius: 28px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.32);
-  padding: clamp(1.75rem, 3vw, 2.9rem);
+  box-shadow: 0 28px 60px rgba(6, 25, 46, 0.28);
+  padding: clamp(1.75rem, 3vw, 3rem);
   display: flex;
   flex-direction: column;
-  gap: clamp(1.25rem, 3vw, 2.25rem);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .word-bank__header {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.5rem;
 }
 
-.word-bank__prompt {
+.word-bank__title {
   margin: 0;
-  font-size: clamp(1.75rem, 4vw, 2.4rem);
+  font-size: clamp(1.6rem, 3.5vw, 2.4rem);
   font-weight: 700;
   letter-spacing: 0.015em;
+  color: var(--word-bank-text);
+}
+
+.word-bank__hero {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.8rem);
+}
+
+.word-bank__mascot {
+  width: clamp(64px, 12vw, 92px);
+  height: clamp(64px, 12vw, 92px);
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.word-bank__bubble {
+  position: relative;
+  flex: 1;
+  background: #ffffff;
+  border-radius: 22px;
+  padding: clamp(1rem, 2.5vw, 1.5rem) clamp(1.25rem, 3vw, 2.1rem);
+  box-shadow: 0 18px 42px rgba(20, 50, 82, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.word-bank__bubble::after {
+  content: '';
+  position: absolute;
+  left: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 24px;
+  background: #ffffff;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  box-shadow: 0 18px 42px rgba(20, 50, 82, 0.16);
+}
+
+.word-bank__bubble-label {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--word-bank-muted);
+}
+
+.word-bank__assembled {
+  min-height: 74px;
+  border-radius: 16px;
+  border: 2px dashed rgba(32, 54, 86, 0.16);
+  background: rgba(15, 36, 64, 0.04);
+  padding: clamp(0.75rem, 2.4vw, 1.1rem);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.word-bank__assembled--filled {
+  border-color: rgba(32, 54, 86, 0.32);
+  background: rgba(15, 36, 64, 0.08);
+}
+
+.word-bank__assembled--correct {
+  border-color: rgba(30, 195, 139, 0.7);
+  background: rgba(30, 195, 139, 0.12);
+}
+
+.word-bank__assembled--error {
+  border-color: rgba(224, 86, 102, 0.8);
+  background: rgba(224, 86, 102, 0.12);
+}
+
+.word-bank__assembled-placeholder {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(32, 54, 86, 0.45);
 }
 
 .word-bank__instructions {
   margin: 0;
-  font-size: 1rem;
-  color: var(--exercise-muted);
+  font-size: 1.05rem;
+  color: var(--word-bank-muted);
 }
 
-.word-bank__assembled,
-.word-bank__bank {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  min-height: 56px;
-}
-
-.word-bank__assembled {
-  padding: 1rem;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-}
-
-.word-bank__bank {
-  padding: 1rem;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 18px;
-}
-
-.word-bank__tile,
-.word-bank__tile--assembled,
-.word-bank__tile--used {
-  border: none;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.1);
-  color: inherit;
+.word-bank__hint {
+  margin: -0.5rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(32, 54, 86, 0.75);
   font-weight: 600;
-  padding: 0.55rem 0.95rem;
-  cursor: pointer;
-  transition: transform 0.18s ease, background 0.18s ease, opacity 0.18s ease;
 }
 
-.word-bank__tile:hover,
-.word-bank__tile:focus-visible,
-.word-bank__tile--assembled:hover,
-.word-bank__tile--assembled:focus-visible {
-  transform: translateY(-1px);
-  background: rgba(77, 208, 225, 0.22);
+.word-bank__bank {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.exercise__tile.word-bank__tile {
+  border: 1px solid var(--word-bank-border);
+  border-radius: 16px;
+  background: #ffffff;
+  color: var(--word-bank-text);
+  font-weight: 700;
+  font-size: 1.05rem;
+  padding: 0.7rem 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 6px 14px rgba(18, 40, 71, 0.08);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease,
+    background 0.16s ease;
+}
+
+.exercise__tile.word-bank__tile:hover,
+.exercise__tile.word-bank__tile:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(30, 195, 139, 0.45);
+  box-shadow: 0 10px 20px rgba(18, 40, 71, 0.14);
   outline: none;
 }
 
-.word-bank__tile--used {
+.word-bank__tile--selected {
+  background: rgba(30, 195, 139, 0.12);
+  border-color: rgba(30, 195, 139, 0.4);
+}
+
+.word-bank__tile--locked {
+  background: rgba(30, 195, 139, 0.18);
+  border-color: rgba(30, 195, 139, 0.45);
+  color: #0f4131;
+  cursor: default;
+  box-shadow: none;
+}
+
+.word-bank__controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.85rem;
+}
+
+.word-bank__button {
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.75rem 1.75rem;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease, opacity 0.16s ease;
+}
+
+.word-bank__button:disabled {
   opacity: 0.6;
   cursor: default;
 }
 
-.word-bank__footer {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
+.word-bank__button--check {
+  background: var(--word-bank-accent);
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(30, 195, 139, 0.24);
 }
 
-.word-bank__check,
-.word-bank__reset {
-  border-radius: 16px;
-  border: none;
-  padding: 0.7rem 1.6rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-}
-
-.word-bank__check {
-  background: var(--exercise-accent);
-  color: #03252f;
-}
-
-.word-bank__reset {
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--exercise-text);
-}
-
-.word-bank__check:hover,
-.word-bank__check:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 18px rgba(77, 208, 225, 0.25);
+.word-bank__button--check:hover,
+.word-bank__button--check:focus-visible {
+  transform: translateY(-2px);
+  background: var(--word-bank-accent-dark);
+  box-shadow: 0 16px 32px rgba(30, 195, 139, 0.28);
   outline: none;
 }
 
-.word-bank__reset:hover,
-.word-bank__reset:focus-visible {
-  transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.2);
+.word-bank__button--reset {
+  background: rgba(31, 42, 68, 0.08);
+  color: var(--word-bank-text);
+}
+
+.word-bank__button--reset:hover,
+.word-bank__button--reset:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(31, 42, 68, 0.16);
   outline: none;
 }
 
 .word-bank__feedback {
   margin: 0;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
   text-align: center;
+  color: var(--word-bank-muted);
   min-height: 1.5em;
 }
 
 .word-bank__feedback[data-status='success'] {
-  color: rgba(147, 255, 210, 0.95);
+  color: var(--word-bank-accent-dark);
 }
 
 .word-bank__feedback[data-status='error'] {
-  color: var(--exercise-danger);
+  color: var(--word-bank-danger);
 }
 
 .word-bank__feedback[data-status='neutral'] {
-  color: var(--exercise-muted);
+  color: var(--word-bank-muted);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .word-bank {
-    padding: 1.5rem 1.25rem 2.25rem;
+    padding: 1.5rem 1.1rem 2.5rem;
   }
 
   .word-bank__surface {
-    border-radius: 20px;
+    border-radius: 24px;
     padding: 1.5rem;
+    gap: 1.5rem;
   }
 
-  .word-bank__footer {
+  .word-bank__hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .word-bank__mascot {
+    width: 72px;
+    height: 72px;
+  }
+
+  .word-bank__bubble {
+    width: 100%;
+  }
+
+  .word-bank__controls {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .word-bank__check,
-  .word-bank__reset {
+  .word-bank__button {
     width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .word-bank__bank {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+
+  .exercise__tile.word-bank__tile {
+    font-size: 0.98rem;
+    padding: 0.65rem 0.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- parse WordBank prompts from lesson markdown and expose lesson-loading helpers for other exercises
- rebuild the WordBank exercise to assemble prompts from lesson data with improved Duolingo-inspired UI and gameplay states
- add configurable override support plus new shared helper to gather vocab across lessons for distractors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcda0642448330a106be0ea0843818