### PR TITLE
Add Word Bank exercises to lesson simulator

### DIFF
--- a/app.js
+++ b/app.js
@@ -482,6 +482,18 @@ const LESSON_SIMULATOR_EXERCISES = [
     loader: () => loadExerciseModule('TranslateToBase/index.js')
   },
   {
+    id: 'wordbank-sinhala',
+    label: 'WordBank (Sinhala)',
+    description: 'Assemble Sinhala sentence from English prompt.',
+    loader: () => loadExerciseModule('WordBankSinhala/index.js')
+  },
+  {
+    id: 'wordbank-english',
+    label: 'WordBank (English)',
+    description: 'Assemble English sentence from Sinhala prompt.',
+    loader: () => loadExerciseModule('WordBankEnglish/index.js')
+  },
+  {
     id: 'picture-choice',
     label: 'Picture Choice',
     description: 'Choose the image that best matches the cue.',

--- a/assets/Lessons/exercises/WordBankEnglish/index.js
+++ b/assets/Lessons/exercises/WordBankEnglish/index.js
@@ -1,0 +1,236 @@
+import {
+  loadSectionSentences,
+  flattenSentences,
+  randomItem,
+  shuffleArray,
+} from '../_shared/wordBankUtils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="wordbank-english"]';
+
+export default async function initWordBankEnglishExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('WordBankEnglish requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('WordBankEnglish target element not found.');
+  }
+
+  target.innerHTML = '<p>Loading sentences…</p>';
+
+  try {
+    const units = await loadSectionSentences();
+    const sentences = flattenSentences(units);
+    if (!sentences.length) {
+      target.innerHTML = '<p>No sentences available.</p>';
+      return;
+    }
+
+    setupExercise(target, sentences, { onComplete });
+  } catch (error) {
+    console.error('Failed to initialise WordBankEnglish exercise', error);
+    target.innerHTML = '<p>Unable to load sentences.</p>';
+  }
+}
+
+function setupExercise(container, sentences, { onComplete } = {}) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'wordbank wordbank--english';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Word Bank (English)';
+  wrapper.appendChild(title);
+
+  const promptLabel = document.createElement('p');
+  promptLabel.textContent = 'Sinhala prompt:';
+  wrapper.appendChild(promptLabel);
+
+  const prompt = document.createElement('p');
+  prompt.className = 'wordbank__prompt';
+  wrapper.appendChild(prompt);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'wordbank__instructions';
+  instructions.textContent = 'Arrange the English tiles to match the Sinhala prompt.';
+  wrapper.appendChild(instructions);
+
+  const tileContainer = document.createElement('div');
+  tileContainer.className = 'wordbank__tiles';
+  wrapper.appendChild(tileContainer);
+
+  const answerLabel = document.createElement('p');
+  answerLabel.textContent = 'Your answer:';
+  wrapper.appendChild(answerLabel);
+
+  const answerContainer = document.createElement('div');
+  answerContainer.className = 'wordbank__answer';
+  wrapper.appendChild(answerContainer);
+
+  const feedback = document.createElement('div');
+  feedback.className = 'wordbank__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(feedback);
+
+  const actions = document.createElement('div');
+  actions.className = 'wordbank__actions';
+  wrapper.appendChild(actions);
+
+  const checkBtn = document.createElement('button');
+  checkBtn.type = 'button';
+  checkBtn.textContent = 'Check';
+  checkBtn.disabled = true;
+  actions.appendChild(checkBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.textContent = 'Clear';
+  actions.appendChild(clearBtn);
+
+  const nextBtn = document.createElement('button');
+  nextBtn.type = 'button';
+  nextBtn.textContent = 'Next';
+  actions.appendChild(nextBtn);
+
+  if (typeof onComplete === 'function') {
+    const finishBtn = document.createElement('button');
+    finishBtn.type = 'button';
+    finishBtn.textContent = 'Finish';
+    finishBtn.addEventListener('click', () => {
+      onComplete();
+    });
+    actions.appendChild(finishBtn);
+  }
+
+  container.innerHTML = '';
+  container.appendChild(wrapper);
+
+  let currentSentence = null;
+  let tiles = [];
+  let answer = [];
+
+  function setSentence(sentence) {
+    currentSentence = sentence;
+    if (!sentence) {
+      prompt.textContent = '';
+      tileContainer.innerHTML = '';
+      answerContainer.textContent = '';
+      setFeedback('');
+      return;
+    }
+
+    prompt.textContent = Array.isArray(sentence.tokens) ? sentence.tokens.join(' ') : '';
+    tiles = buildEnglishTiles(sentence);
+    answer = [];
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function buildEnglishTiles(sentence) {
+    const words = splitEnglishWords(sentence.text);
+    return shuffleArray(
+      words.map((word, index) => ({
+        id: `word-${index}`,
+        text: word,
+        used: false,
+      })),
+    );
+  }
+
+  function updateTiles() {
+    tileContainer.innerHTML = '';
+    tiles.forEach((tile) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = tile.text;
+      button.disabled = tile.used;
+      button.addEventListener('click', () => handleTileSelect(tile));
+      tileContainer.appendChild(button);
+    });
+  }
+
+  function handleTileSelect(tile) {
+    if (!tile || tile.used) {
+      return;
+    }
+    tile.used = true;
+    answer.push(tile);
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function updateAnswer() {
+    answerContainer.textContent = answer.map((entry) => entry.text).join(' ');
+    checkBtn.disabled = answer.length === 0;
+  }
+
+  function setFeedback(message) {
+    feedback.textContent = message || '';
+  }
+
+  function handleCheck() {
+    if (!currentSentence) {
+      return;
+    }
+    const attempt = answer.map((entry) => entry.text);
+    const correct = splitEnglishWords(currentSentence.text || '');
+    const success =
+      attempt.length === correct.length &&
+      attempt.every((word, index) => word === correct[index]);
+
+    if (success) {
+      setFeedback('✅ Correct!');
+    } else {
+      setFeedback(`❌ Correct order: ${correct.join(' ')}`);
+    }
+  }
+
+  function handleClear() {
+    tiles.forEach((tile) => {
+      tile.used = false;
+    });
+    answer = [];
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function handleNext() {
+    if (!sentences.length) {
+      return;
+    }
+    let nextSentence = randomItem(sentences);
+    if (sentences.length > 1) {
+      let guard = 0;
+      while (nextSentence === currentSentence && guard < 10) {
+        nextSentence = randomItem(sentences);
+        guard += 1;
+      }
+    }
+    handleClear();
+    setSentence(nextSentence);
+  }
+
+  checkBtn.addEventListener('click', handleCheck);
+  clearBtn.addEventListener('click', handleClear);
+  nextBtn.addEventListener('click', handleNext);
+
+  setSentence(randomItem(sentences));
+}
+
+function splitEnglishWords(text) {
+  if (typeof text !== 'string') {
+    return [];
+  }
+  return text
+    .split(/\s+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}

--- a/assets/Lessons/exercises/WordBankSinhala/index.js
+++ b/assets/Lessons/exercises/WordBankSinhala/index.js
@@ -1,0 +1,245 @@
+import {
+  loadSectionSentences,
+  flattenSentences,
+  randomItem,
+  shuffleArray,
+} from '../_shared/wordBankUtils.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="wordbank-sinhala"]';
+
+export default async function initWordBankSinhalaExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('WordBankSinhala requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    onComplete,
+  } = options;
+
+  if (!target) {
+    throw new Error('WordBankSinhala target element not found.');
+  }
+
+  target.innerHTML = '<p>Loading sentences…</p>';
+
+  try {
+    const units = await loadSectionSentences();
+    const sentences = flattenSentences(units);
+    if (!sentences.length) {
+      target.innerHTML = '<p>No sentences available.</p>';
+      return;
+    }
+
+    setupExercise(target, sentences, { onComplete });
+  } catch (error) {
+    console.error('Failed to initialise WordBankSinhala exercise', error);
+    target.innerHTML = '<p>Unable to load sentences.</p>';
+  }
+}
+
+function setupExercise(container, sentences, { onComplete } = {}) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'wordbank wordbank--sinhala';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Word Bank (Sinhala)';
+  wrapper.appendChild(title);
+
+  const prompt = document.createElement('p');
+  prompt.className = 'wordbank__prompt';
+  wrapper.appendChild(prompt);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'wordbank__instructions';
+  instructions.textContent = 'Arrange the Sinhala tiles to match the English sentence.';
+  wrapper.appendChild(instructions);
+
+  const tileContainer = document.createElement('div');
+  tileContainer.className = 'wordbank__tiles';
+  wrapper.appendChild(tileContainer);
+
+  const answerLabel = document.createElement('p');
+  answerLabel.textContent = 'Your answer:';
+  wrapper.appendChild(answerLabel);
+
+  const answerContainer = document.createElement('div');
+  answerContainer.className = 'wordbank__answer';
+  wrapper.appendChild(answerContainer);
+
+  const feedback = document.createElement('div');
+  feedback.className = 'wordbank__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(feedback);
+
+  const actions = document.createElement('div');
+  actions.className = 'wordbank__actions';
+  wrapper.appendChild(actions);
+
+  const checkBtn = document.createElement('button');
+  checkBtn.type = 'button';
+  checkBtn.textContent = 'Check';
+  checkBtn.disabled = true;
+  actions.appendChild(checkBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.textContent = 'Clear';
+  actions.appendChild(clearBtn);
+
+  const nextBtn = document.createElement('button');
+  nextBtn.type = 'button';
+  nextBtn.textContent = 'Next';
+  actions.appendChild(nextBtn);
+
+  if (typeof onComplete === 'function') {
+    const finishBtn = document.createElement('button');
+    finishBtn.type = 'button';
+    finishBtn.textContent = 'Finish';
+    finishBtn.addEventListener('click', () => {
+      onComplete();
+    });
+    actions.appendChild(finishBtn);
+  }
+
+  container.innerHTML = '';
+  container.appendChild(wrapper);
+
+  let currentSentence = null;
+  let tiles = [];
+  let answer = [];
+
+  function setSentence(sentence) {
+    currentSentence = sentence;
+    if (!sentence) {
+      prompt.textContent = '';
+      tileContainer.innerHTML = '';
+      answerContainer.textContent = '';
+      setFeedback('');
+      return;
+    }
+
+    prompt.textContent = sentence.text || '';
+    tiles = buildSinhalaTiles(sentence);
+    answer = [];
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function buildSinhalaTiles(sentence) {
+    const tileEntries = [];
+    const tokens = Array.isArray(sentence.tokens) ? sentence.tokens : [];
+    tokens.forEach((token, index) => {
+      tileEntries.push({
+        id: `token-${index}`,
+        text: token,
+        used: false,
+      });
+    });
+
+    const seenDistractors = new Set();
+    const unitVocab = Array.isArray(sentence.unitVocab) ? sentence.unitVocab : [];
+    unitVocab.forEach((word) => {
+      if (!word || typeof word !== 'string') {
+        return;
+      }
+      if (tokens.includes(word)) {
+        return;
+      }
+      if (seenDistractors.has(word)) {
+        return;
+      }
+      seenDistractors.add(word);
+      tileEntries.push({
+        id: `extra-${word}`,
+        text: word,
+        used: false,
+      });
+    });
+
+    return shuffleArray(tileEntries);
+  }
+
+  function updateTiles() {
+    tileContainer.innerHTML = '';
+    tiles.forEach((tile) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = tile.text;
+      button.disabled = tile.used;
+      button.addEventListener('click', () => handleTileSelect(tile));
+      tileContainer.appendChild(button);
+    });
+  }
+
+  function handleTileSelect(tile) {
+    if (!tile || tile.used) {
+      return;
+    }
+    tile.used = true;
+    answer.push(tile);
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function updateAnswer() {
+    answerContainer.textContent = answer.map((entry) => entry.text).join(' ');
+    checkBtn.disabled = answer.length === 0;
+  }
+
+  function setFeedback(message) {
+    feedback.textContent = message || '';
+  }
+
+  function handleCheck() {
+    if (!currentSentence) {
+      return;
+    }
+    const attempt = answer.map((entry) => entry.text);
+    const correct = Array.isArray(currentSentence.tokens) ? currentSentence.tokens : [];
+    const success =
+      attempt.length === correct.length &&
+      attempt.every((word, index) => word === correct[index]);
+
+    if (success) {
+      setFeedback('✅ Correct!');
+    } else {
+      setFeedback(`❌ Correct order: ${correct.join(' ')}`);
+    }
+  }
+
+  function handleClear() {
+    tiles.forEach((tile) => {
+      tile.used = false;
+    });
+    answer = [];
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function handleNext() {
+    if (!sentences.length) {
+      return;
+    }
+    let nextSentence = randomItem(sentences);
+    if (sentences.length > 1) {
+      let guard = 0;
+      while (nextSentence === currentSentence && guard < 10) {
+        nextSentence = randomItem(sentences);
+        guard += 1;
+      }
+    }
+    handleClear();
+    setSentence(nextSentence);
+  }
+
+  checkBtn.addEventListener('click', handleCheck);
+  clearBtn.addEventListener('click', handleClear);
+  nextBtn.addEventListener('click', handleNext);
+
+  setSentence(randomItem(sentences));
+}

--- a/assets/Lessons/exercises/_shared/vocabMap.js
+++ b/assets/Lessons/exercises/_shared/vocabMap.js
@@ -1,0 +1,47 @@
+export const vocabMap = {
+  ayubowan: { si: 'ආයුබෝවන්', translit: 'ayubowan' },
+  oya: { si: 'ඔයා', translit: 'oya' },
+  kohomada: { si: 'කොහොමද', translit: 'kohomada' },
+  mama: { si: 'මම', translit: 'mama' },
+  hondai: { si: 'හොඳයි', translit: 'hondai' },
+  ohu: { si: 'ඔහු', translit: 'ohu' },
+  eya: { si: 'ඇය', translit: 'eya' },
+  mage: { si: 'මගේ', translit: 'mage' },
+  nama: { si: 'නම', translit: 'nama' },
+  yaluwa: { si: 'යාලුවා', translit: 'yaluwa' },
+  rata: { si: 'රට', translit: 'rata' },
+  gena: { si: 'ගැන', translit: 'gena' },
+  Sri_Lanka: { si: 'ශ්‍රී ලංකාව', translit: 'Sri Lanka' },
+  Australia: { si: 'ඕස්ට්‍රේලියාව', translit: 'Australia' },
+  India: { si: 'ඉන්දියාව', translit: 'India' },
+  vissara: { si: 'වයස', translit: 'vissara' },
+  ganan: { si: 'ගණන්', translit: 'ganan' },
+  dahaya: { si: 'දහය', translit: 'dahaya' },
+  visi: { si: 'විසි', translit: 'visi' },
+  tis: { si: 'තිස්', translit: 'tis' },
+  kathaa: { si: 'කතා', translit: 'kathaa' },
+  Sinhala: { si: 'සිංහල', translit: 'Sinhala' },
+  English: { si: 'ඉංග්‍රීසි', translit: 'English' },
+  Tamil: { si: 'දෙමළ', translit: 'Tamil' }
+};
+
+export function getVocabEntry(token) {
+  const key = typeof token === 'string' ? token : '';
+  if (!key) {
+    return { si: '', translit: '' };
+  }
+  const entry = vocabMap[key];
+  if (entry) {
+    return {
+      si: entry.si || key,
+      translit: entry.translit || key
+    };
+  }
+  const fallback = key.replace(/_/g, ' ');
+  return {
+    si: fallback,
+    translit: fallback
+  };
+}
+
+export default vocabMap;

--- a/assets/Lessons/exercises/_shared/wordBankUtils.js
+++ b/assets/Lessons/exercises/_shared/wordBankUtils.js
@@ -1,0 +1,238 @@
+const SENTENCES_URL = new URL('../../sections/section-01-introductions/sentences.yaml', import.meta.url);
+
+let cachedUnitsPromise = null;
+
+export function shuffleArray(input) {
+  const array = Array.isArray(input) ? input.slice() : [];
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+export function randomItem(array) {
+  if (!Array.isArray(array) || array.length === 0) {
+    return null;
+  }
+  const index = Math.floor(Math.random() * array.length);
+  return array[index] ?? null;
+}
+
+export async function loadSectionSentences() {
+  if (!cachedUnitsPromise) {
+    cachedUnitsPromise = fetchSectionUnits();
+  }
+  const units = await cachedUnitsPromise;
+  return units.map((unit) => ({
+    id: unit.id,
+    name: unit.name,
+    vocab: Array.isArray(unit.vocab) ? unit.vocab.slice() : [],
+    sentences: Array.isArray(unit.sentences)
+      ? unit.sentences.map((sentence) => ({ ...sentence }))
+      : [],
+  }));
+}
+
+async function fetchSectionUnits() {
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetching sentences requires a browser environment.');
+  }
+
+  const response = await fetch(SENTENCES_URL, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error('Failed to load section sentences.');
+  }
+
+  const text = await response.text();
+  return parseSectionYaml(text);
+}
+
+export function flattenSentences(units) {
+  if (!Array.isArray(units)) {
+    return [];
+  }
+
+  const sentences = [];
+  units.forEach((unit) => {
+    const vocab = Array.isArray(unit.vocab) ? unit.vocab : [];
+    const unitSentences = Array.isArray(unit.sentences) ? unit.sentences : [];
+    unitSentences.forEach((sentence) => {
+      sentences.push({
+        text: sentence.text || '',
+        tokens: Array.isArray(sentence.tokens) ? sentence.tokens.slice() : [],
+        minUnit: sentence.minUnit ?? null,
+        unit,
+        unitVocab: vocab,
+      });
+    });
+  });
+
+  return sentences;
+}
+
+function parseSectionYaml(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return [];
+  }
+
+  const units = [];
+  const lines = text.split(/\r?\n/);
+  let currentUnit = null;
+  let currentSentence = null;
+  let mode = null;
+
+  lines.forEach((line) => {
+    if (!line) {
+      return;
+    }
+
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+
+    if (trimmed.startsWith('- id:')) {
+      const idValue = trimmed.replace(/^- id:\s*/, '').trim();
+      const parsedId = Number(idValue) || idValue;
+      currentUnit = {
+        id: parsedId,
+        name: '',
+        vocab: [],
+        sentences: [],
+      };
+      units.push(currentUnit);
+      mode = null;
+      currentSentence = null;
+      return;
+    }
+
+    if (!currentUnit) {
+      return;
+    }
+
+    if (trimmed.startsWith('name:')) {
+      const value = trimmed.replace(/^name:\s*/, '').trim();
+      currentUnit.name = stripQuotes(value);
+      return;
+    }
+
+    if (trimmed === 'vocab:') {
+      mode = 'vocab';
+      currentSentence = null;
+      return;
+    }
+
+    if (trimmed === 'sentences:') {
+      mode = 'sentences';
+      currentSentence = null;
+      return;
+    }
+
+    if (mode === 'vocab' && trimmed.startsWith('- ')) {
+      const vocabEntry = trimmed.replace(/^-\s*/, '');
+      const cleaned = stripComment(vocabEntry);
+      if (cleaned) {
+        currentUnit.vocab.push(cleaned);
+      }
+      return;
+    }
+
+    if (mode === 'sentences') {
+      if (trimmed.startsWith('- text:')) {
+        const value = trimmed.replace(/^- text:\s*/, '');
+        const textValue = parseQuotedValue(value);
+        currentSentence = {
+          text: textValue,
+          tokens: [],
+          minUnit: null,
+        };
+        currentUnit.sentences.push(currentSentence);
+        return;
+      }
+
+      if (!currentSentence) {
+        return;
+      }
+
+      if (trimmed.startsWith('tokens:')) {
+        const tokenText = trimmed.replace(/^tokens:\s*/, '');
+        currentSentence.tokens = parseArrayLiteral(tokenText);
+        return;
+      }
+
+      if (trimmed.startsWith('minUnit:')) {
+        const value = trimmed.replace(/^minUnit:\s*/, '').trim();
+        const parsed = Number(value);
+        currentSentence.minUnit = Number.isNaN(parsed) ? value : parsed;
+        return;
+      }
+    }
+  });
+
+  return units;
+}
+
+function parseQuotedValue(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const firstChar = trimmed[0];
+  const lastChar = trimmed[trimmed.length - 1];
+  if (firstChar === '"' && lastChar === '"') {
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (firstChar === '\'' && lastChar === '\'') {
+    const inner = trimmed.slice(1, -1);
+    try {
+      return JSON.parse(`"${inner.replace(/"/g, '\\"')}"`);
+    } catch (error) {
+      return inner;
+    }
+  }
+  return stripQuotes(trimmed);
+}
+
+function parseArrayLiteral(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    return trimmed
+      .replace(/^[\[]|[\]]$/g, '')
+      .split(',')
+      .map((item) => stripQuotes(item.trim()))
+      .filter(Boolean);
+  }
+}
+
+function stripComment(value) {
+  const noComment = value.replace(/\s+#.*$/, '');
+  return stripQuotes(noComment.trim());
+}
+
+function stripQuotes(value) {
+  if (!value) {
+    return '';
+  }
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith('\'') && trimmed.endsWith('\''))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export default {
+  loadSectionSentences,
+  flattenSentences,
+  shuffleArray,
+  randomItem,
+};

--- a/assets/Lessons/exercises/_shared/wordBankUtils.js
+++ b/assets/Lessons/exercises/_shared/wordBankUtils.js
@@ -71,6 +71,51 @@ export function flattenSentences(units) {
   return sentences;
 }
 
+export function determineUnitId(candidate) {
+  if (candidate == null) {
+    if (typeof window !== 'undefined') {
+      const lesson = window.BashaLanka && window.BashaLanka.currentLesson;
+      const detailUnit = lesson?.detail?.unitId ?? lesson?.meta?.unitId;
+      const numericDetail = Number(detailUnit);
+      if (!Number.isNaN(numericDetail) && numericDetail > 0) {
+        return numericDetail;
+      }
+    }
+    return 1;
+  }
+
+  const numeric = Number(candidate);
+  if (Number.isNaN(numeric) || numeric <= 0) {
+    return 1;
+  }
+  return numeric;
+}
+
+export function filterUnlockedSentences(sentences, unitId) {
+  if (!Array.isArray(sentences)) {
+    return [];
+  }
+
+  const resolvedUnitId = determineUnitId(unitId);
+  return sentences.filter((sentence) => {
+    if (!sentence) {
+      return false;
+    }
+
+    const { minUnit } = sentence;
+    if (minUnit == null || minUnit === '') {
+      return true;
+    }
+
+    const numeric = Number(minUnit);
+    if (Number.isNaN(numeric)) {
+      return true;
+    }
+
+    return numeric <= resolvedUnitId;
+  });
+}
+
 function parseSectionYaml(text) {
   if (typeof text !== 'string' || !text.trim()) {
     return [];
@@ -235,4 +280,6 @@ export default {
   flattenSentences,
   shuffleArray,
   randomItem,
+  filterUnlockedSentences,
+  determineUnitId,
 };

--- a/assets/Lessons/sections/section-01-introductions/words.yaml
+++ b/assets/Lessons/sections/section-01-introductions/words.yaml
@@ -1,56 +1,78 @@
-Section01-Words:
+# Section 01 — Introductions & Essentials
+# Complete CEFR A1 baseline word list
+
+section-01-words:
+
   unit-01-pronouns-greetings:
-    - { si: "මම", translit: "mama", en: "I" }
-    - { si: "ඔයා", translit: "oyā", en: "you (casual)" }
-    - { si: "ඔහු", translit: "ohu", en: "he" }
-    - { si: "ඇය", translit: "eya", en: "she" }
-    - { si: "ඔබ", translit: "oba", en: "you (formal)" }
-    - { si: "කොහොමද?", translit: "kohomada?", en: "how?" }
-    - { si: "හොඳයි", translit: "hondayi", en: "fine / good" }
-    - { si: "ආයුබෝවන්", translit: "āyubōvan", en: "formal greeting (hello)" }
+    - {si: "මම", translit: "mama", en: "I"}
+    - {si: "ඔයා", translit: "oyā", en: "you (casual)"}
+    - {si: "ඔහු", translit: "ohu", en: "he"}
+    - {si: "ඇය", translit: "eya", en: "she"}
+    - {si: "ඔව්", translit: "owu", en: "yes"}
+    - {si: "නෑ", translit: "næ", en: "no"}
+    - {si: "කොහොමද?", translit: "kohomada?", en: "how?"}
+    - {si: "හොඳයි", translit: "hondayi", en: "fine / good"}
+    - {si: "ආයුබෝවන්", translit: "āyubōvan", en: "formal hello / greeting"}
 
   unit-02-introducing-yourself:
-    - { si: "ගේ", translit: "gé", en: "possessive marker ('s)" }
-    - { si: "මගේ", translit: "magē", en: "my" }
-    - { si: "ඔයාගේ", translit: "oyāgē", en: "your (informal)" }
-    - { si: "ඔබගේ", translit: "obagē", en: "your (formal)" }
-    - { si: "ඒයාගේ", translit: "eyāgē", en: "her" }
-    - { si: "ඔහුගේ", translit: "ohugē", en: "his" }
-    - { si: "නම", translit: "nama", en: "name" }
-    - { si: "මොකක්ද?", translit: "mokakda?", en: "what?" }
-    - { si: "ස්තුතියි", translit: "stūthiyi", en: "thank you" }
-    - { si: "ස්තුති", translit: "sthuthi", en: "thank you" }
-    - { si: "හොඳින්", translit: "hondin", en: "well" }
-    - { si: "ඉන්නවා", translit: "innavā", en: "to be / to stay" }
+    - {si: "ගේ", translit: "gé", en: "possessive marker (of)"}
+    - {si: "මගේ", translit: "magē", en: "my"}
+    - {si: "ඔයාගේ", translit: "oyāgē", en: "your (casual)"}
+    - {si: "ඔබගේ", translit: "obagē", en: "your (formal)"}
+    - {si: "ඒයාගේ / ඔහුගේ", translit: "eyāgē / ohugē", en: "her / his"}
+    - {si: "නම", translit: "nama", en: "name"}
+    - {si: "මම [name]", translit: "mama [name]", en: "I am [name]"}
+    - {si: "මගේ නම [name]", translit: "magē nama [name]", en: "My name is [name]"}
+    - {si: "මොකක්ද?", translit: "mokakda?", en: "what?"}
+    - {si: "ස්තුතියි", translit: "stūthiyi", en: "thank you"}
+    - {si: "ස්තුති", translit: "sthuthi", en: "thanks"}
+    - {si: "සමාවෙන්න", translit: "samāvenna", en: "sorry / excuse me"}
+    - {si: "කරුණාකර", translit: "karuṇākara", en: "please"}
 
   unit-03-nationalities:
-    - { si: "රට", translit: "raṭa", en: "country" }
-    - { si: "ශ්‍රී ලංකාව", translit: "Sri Lankāva", en: "Sri Lanka" }
-    - { si: "ඉන්දියාව", translit: "Indiyāva", en: "India" }
-    - { si: "ශ්‍රී ලංකාවෙන්", translit: "Sri Lankāven", en: "from Sri Lanka" }
-    - { si: "ඕස්ට්‍රේලියාව", translit: "Ōstrēliyāva", en: "Australia" }
-    - { si: "ඕස්ට්‍රේලියාවෙන්", translit: "Ōstrēliyāven", en: "from Australia" }
-    - { si: "ඉංග්‍රැන්ඩුවෙන්", translit: "Inglanduven", en: "from England" }
-    - { si: "වෙන්", translit: "ven", en: "from (suffix -en)" }
-    - { si: "වෙන්නේ", translit: "venne", en: "to be / to become (from)" }
-    - { si: "ද?", translit: "da?", en: "yes/no question marker" }
+    - {si: "රට", translit: "raṭa", en: "country"}
+    - {si: "…වෙන්", translit: "…ven", en: "from (suffix)"}
+    - {si: "ශ්‍රී ලංකාව", translit: "Sri Lankāva", en: "Sri Lanka"}
+    - {si: "ඉන්දියාව", translit: "Indiyāva", en: "India"}
+    - {si: "ඉංග්ලන්තය", translit: "Inglandaya", en: "England"}
+    - {si: "ඕස්ට්‍රේලියාව", translit: "Ōstrēliyāva", en: "Australia"}
+    - {si: "මම …වෙන්", translit: "mama …ven", en: "I am from …"}
+    - {si: "ද?", translit: "da?", en: "yes/no question marker"}
 
-  unit-04-age:
-    - { si: "අපි", translit: "api", en: "we" }
-    - { si: "ඔයාල", translit: "oyāla", en: "you (plural, informal)" }
-    - { si: "ඔබලා", translit: "obalā", en: "you (plural, formal)" }
-    - { si: "ඒයාල", translit: "eyāla", en: "they" }
-    - { si: "අපේ", translit: "apē", en: "our" }
-    - { si: "ඔයාලගේ", translit: "oyālagē", en: "your (plural, informal)" }
-    - { si: "ඔබලාගේ", translit: "obalāgē", en: "your (plural, formal)" }
-    - { si: "ඒයාලගේ", translit: "eyālagē", en: "their" }
-    - { si: "වයස", translit: "vayasa", en: "age" }
-    - { si: "කීයද?", translit: "kieyda?", en: "how much? / how many?" }
-    - { si: "තිහයි", translit: "tihayi", en: "thirty" }
-    - { si: "විසිපහයි", translit: "visipahayi", en: "twenty-five" }
+  unit-04-age-numbers:
+    - {si: "අපි", translit: "api", en: "we"}
+    - {si: "ඔයාල", translit: "oyāla", en: "you (plural, informal)"}
+    - {si: "ඔබලා", translit: "obalā", en: "you (plural, formal)"}
+    - {si: "ඒයාල", translit: "eyāla", en: "they"}
+    - {si: "අපේ", translit: "apē", en: "our"}
+    - {si: "වයස", translit: "vayasa", en: "age"}
+    - {si: "කීයද?", translit: "kieyda?", en: "how much? / how many?"}
+    # Numbers 1–20
+    - {si: "එක", translit: "eka", en: "one"}
+    - {si: "දෙක", translit: "deka", en: "two"}
+    - {si: "තුන", translit: "thuna", en: "three"}
+    - {si: "හතර", translit: "hathara", en: "four"}
+    - {si: "පහ", translit: "paha", en: "five"}
+    - {si: "හය", translit: "haya", en: "six"}
+    - {si: "හත", translit: "hatha", en: "seven"}
+    - {si: "අට", translit: "ata", en: "eight"}
+    - {si: "නවය", translit: "navaya", en: "nine"}
+    - {si: "දහය", translit: "dahaya", en: "ten"}
+    - {si: "එකොළහ", translit: "ekolaha", en: "eleven"}
+    - {si: "දොළහ", translit: "dolaha", en: "twelve"}
+    - {si: "දහතුන", translit: "dahathuna", en: "thirteen"}
+    - {si: "දහහතර", translit: "dahahathara", en: "fourteen"}
+    - {si: "පහළොස්", translit: "pahalos", en: "fifteen"}
+    - {si: "දහසය", translit: "dahasaya", en: "sixteen"}
+    - {si: "දහහත", translit: "dahahatha", en: "seventeen"}
+    - {si: "දහඅට", translit: "dahaata", en: "eighteen"}
+    - {si: "දහනවය", translit: "dahanavaya", en: "nineteen"}
+    - {si: "විස්සි", translit: "visi", en: "twenty"}
 
   unit-05-languages:
-    - { si: "කරනවා", translit: "karanavā", en: "do / doing" }
-    - { si: "කතා", translit: "kathā", en: "speech / talk" }
-    - { si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English" }
-    - { si: "සිංහල", translit: "siṁhala", en: "Sinhala" }
+    - {si: "කරනවා", translit: "karanavā", en: "do / doing"}
+    - {si: "කතා", translit: "kathā", en: "speech / talk"}
+    - {si: "කතා කරනවා", translit: "kathā karanavā", en: "speak / speaking"}
+    - {si: "සිංහල", translit: "siṁhala", en: "Sinhala"}
+    - {si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English"}
+    - {si: "දෙමළ", translit: "demala", en: "Tamil"}

--- a/assets/Lessons/sections/section-01-introductions/words.yaml
+++ b/assets/Lessons/sections/section-01-introductions/words.yaml
@@ -1,0 +1,58 @@
+Section01-Words:
+  unit-01-pronouns-greetings:
+    - { si: "මම", translit: "mama", en: "I" }
+    - { si: "ඔයා", translit: "oyā", en: "you (casual)" }
+    - { si: "ඔහු", translit: "ohu", en: "he" }
+    - { si: "ඇය", translit: "eya", en: "she" }
+    - { si: "ඔබ", translit: "oba", en: "you (formal)" }
+    - { si: "කොහොමද?", translit: "kohomada?", en: "how?" }
+    - { si: "හොඳයි", translit: "hondayi", en: "fine / good" }
+    - { si: "ආයුබෝවන්", translit: "āyubōvan", en: "formal greeting (hello)" }
+
+  unit-02-introducing-yourself:
+    - { si: "ගේ", translit: "gé", en: "possessive marker ('s)" }
+    - { si: "මගේ", translit: "magē", en: "my" }
+    - { si: "ඔයාගේ", translit: "oyāgē", en: "your (informal)" }
+    - { si: "ඔබගේ", translit: "obagē", en: "your (formal)" }
+    - { si: "ඒයාගේ", translit: "eyāgē", en: "her" }
+    - { si: "ඔහුගේ", translit: "ohugē", en: "his" }
+    - { si: "නම", translit: "nama", en: "name" }
+    - { si: "මොකක්ද?", translit: "mokakda?", en: "what?" }
+    - { si: "ස්තුතියි", translit: "stūthiyi", en: "thank you" }
+    - { si: "ස්තුති", translit: "sthuthi", en: "thanks" }
+    - { si: "හොඳින්", translit: "hondin", en: "well" }
+    - { si: "ඉන්නවා", translit: "innavā", en: "to be / to stay" }
+
+  unit-03-nationalities:
+    - { si: "රට", translit: "raṭa", en: "country" }
+    - { si: "ශ්‍රී ලංකාව", translit: "Sri Lankāva", en: "Sri Lanka" }
+    - { si: "ශ්‍රී ලංකාවෙන්", translit: "Sri Lankāven", en: "from Sri Lanka" }
+    - { si: "ඉන්දියාව", translit: "Indiyāva", en: "India" }
+    - { si: "ඕස්ට්‍රේලියාව", translit: "Ōstrēliyāva", en: "Australia" }
+    - { si: "ඕස්ට්‍රේලියාවෙන්", translit: "Ōstrēliyāven", en: "from Australia" }
+    - { si: "ඉංග්‍රැන්ඩුවෙන්", translit: "Inglanduven", en: "from England" }
+    - { si: "වෙන්", translit: "ven", en: "from (suffix -en)" }
+    - { si: "වෙන්නේ", translit: "venne", en: "to be / to become (from)" }
+    - { si: "ද?", translit: "da?", en: "yes/no question marker" }
+
+  unit-04-age:
+    - { si: "අපි", translit: "api", en: "we" }
+    - { si: "ඔයාල", translit: "oyāla", en: "you (plural, informal)" }
+    - { si: "ඔබලා", translit: "obalā", en: "you (plural, formal)" }
+    - { si: "ඒයාල", translit: "eyāla", en: "they" }
+    - { si: "අපේ", translit: "apē", en: "our" }
+    - { si: "ඔයාලගේ", translit: "oyālagē", en: "your (plural, informal)" }
+    - { si: "ඔබලාගේ", translit: "obalāgē", en: "your (plural, formal)" }
+    - { si: "ඒයාලගේ", translit: "eyālagē", en: "their" }
+    - { si: "වයස", translit: "vayasa", en: "age" }
+    - { si: "කීයද?", translit: "kieyda?", en: "how much? / how many?" }
+    - { si: "තිහයි", translit: "tihayi", en: "is thirty" }
+    - { si: "විසිපහයි", translit: "visipahayi", en: "is twenty-five" }
+
+  unit-05-languages:
+    - { si: "කරනවා", translit: "karanavā", en: "do / doing" }
+    - { si: "කතා", translit: "kathā", en: "speech / talk" }
+    - { si: "කතා කරනවා", translit: "kathā karanavā", en: "speak / to speak" }
+    - { si: "කරනවාද?", translit: "karanavāda?", en: "do you (do)?" }
+    - { si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English" }
+    - { si: "සිංහල", translit: "siṁhala", en: "Sinhala" }

--- a/assets/Lessons/sections/section-01-introductions/words.yaml
+++ b/assets/Lessons/sections/section-01-introductions/words.yaml
@@ -19,15 +19,15 @@ Section01-Words:
     - { si: "නම", translit: "nama", en: "name" }
     - { si: "මොකක්ද?", translit: "mokakda?", en: "what?" }
     - { si: "ස්තුතියි", translit: "stūthiyi", en: "thank you" }
-    - { si: "ස්තුති", translit: "sthuthi", en: "thanks" }
+    - { si: "ස්තුති", translit: "sthuthi", en: "thank you" }
     - { si: "හොඳින්", translit: "hondin", en: "well" }
     - { si: "ඉන්නවා", translit: "innavā", en: "to be / to stay" }
 
   unit-03-nationalities:
     - { si: "රට", translit: "raṭa", en: "country" }
     - { si: "ශ්‍රී ලංකාව", translit: "Sri Lankāva", en: "Sri Lanka" }
-    - { si: "ශ්‍රී ලංකාවෙන්", translit: "Sri Lankāven", en: "from Sri Lanka" }
     - { si: "ඉන්දියාව", translit: "Indiyāva", en: "India" }
+    - { si: "ශ්‍රී ලංකාවෙන්", translit: "Sri Lankāven", en: "from Sri Lanka" }
     - { si: "ඕස්ට්‍රේලියාව", translit: "Ōstrēliyāva", en: "Australia" }
     - { si: "ඕස්ට්‍රේලියාවෙන්", translit: "Ōstrēliyāven", en: "from Australia" }
     - { si: "ඉංග්‍රැන්ඩුවෙන්", translit: "Inglanduven", en: "from England" }
@@ -46,13 +46,11 @@ Section01-Words:
     - { si: "ඒයාලගේ", translit: "eyālagē", en: "their" }
     - { si: "වයස", translit: "vayasa", en: "age" }
     - { si: "කීයද?", translit: "kieyda?", en: "how much? / how many?" }
-    - { si: "තිහයි", translit: "tihayi", en: "is thirty" }
-    - { si: "විසිපහයි", translit: "visipahayi", en: "is twenty-five" }
+    - { si: "තිහයි", translit: "tihayi", en: "thirty" }
+    - { si: "විසිපහයි", translit: "visipahayi", en: "twenty-five" }
 
   unit-05-languages:
     - { si: "කරනවා", translit: "karanavā", en: "do / doing" }
     - { si: "කතා", translit: "kathā", en: "speech / talk" }
-    - { si: "කතා කරනවා", translit: "kathā karanavā", en: "speak / to speak" }
-    - { si: "කරනවාද?", translit: "karanavāda?", en: "do you (do)?" }
     - { si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English" }
     - { si: "සිංහල", translit: "siṁhala", en: "Sinhala" }


### PR DESCRIPTION
## Summary
- add shared utilities to load section sentences for word bank exercises
- build WordBankSinhala and WordBankEnglish modules that render simple tile-based assembly tasks
- expose both exercises in the lesson simulator menu for admin previews

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4a591dec8330b057199181a43968