### PR TITLE
Refactor word bank exercises to use section YAML data

### DIFF
--- a/assets/Lessons/exercises/WordBankSinhala/index.js
+++ b/assets/Lessons/exercises/WordBankSinhala/index.js
@@ -1,9 +1,11 @@
 import {
-  loadSectionSentences,
-  flattenSentences,
+  loadWordBankUnits,
+  resolveActiveUnit,
+  getUnitSentences,
   randomItem,
   shuffleArray,
-  filterUnlockedSentences,
+  getWordEntryFromUnit,
+  normaliseWordBankToken,
 } from '../_shared/wordBankUtils.js';
 import { getVocabEntry } from '../_shared/vocabMap.js';
 
@@ -27,21 +29,27 @@ export default async function initWordBankSinhalaExercise(options = {}) {
   target.innerHTML = '<p>Loading sentences…</p>';
 
   try {
-    const units = await loadSectionSentences();
-    const sentences = filterUnlockedSentences(flattenSentences(units), providedUnitId);
+    const units = await loadWordBankUnits();
+    const activeUnit = resolveActiveUnit(units, providedUnitId);
+    if (!activeUnit) {
+      target.innerHTML = '<p>No unit data available.</p>';
+      return;
+    }
+
+    const sentences = getUnitSentences(activeUnit);
     if (!sentences.length) {
       target.innerHTML = '<p>No sentences available.</p>';
       return;
     }
 
-    setupExercise(target, sentences, { onComplete });
+    setupExercise(target, activeUnit, sentences, { onComplete });
   } catch (error) {
     console.error('Failed to initialise WordBankSinhala exercise', error);
     target.innerHTML = '<p>Unable to load sentences.</p>';
   }
 }
 
-function setupExercise(container, sentences, { onComplete } = {}) {
+function setupExercise(container, unit, sentences, { onComplete } = {}) {
   const wrapper = document.createElement('section');
   wrapper.className = 'wordbank wordbank--sinhala';
 
@@ -109,6 +117,7 @@ function setupExercise(container, sentences, { onComplete } = {}) {
   container.innerHTML = '';
   container.appendChild(wrapper);
 
+  const unitWords = Array.isArray(unit?.words) ? unit.words : [];
   let currentSentence = null;
   let tiles = [];
   let answer = [];
@@ -134,24 +143,37 @@ function setupExercise(container, sentences, { onComplete } = {}) {
   function buildSinhalaTiles(sentence) {
     const tileEntries = [];
     const tokens = Array.isArray(sentence.tokens) ? sentence.tokens : [];
+    const seenKeys = new Set();
+
     tokens.forEach((token, index) => {
-      tileEntries.push(createTileEntry(token, `token-${index}`));
+      tileEntries.push(createTileEntry(unit, token, `token-${index}`));
+      const normalised = normaliseWordBankToken(token);
+      if (normalised) {
+        seenKeys.add(normalised);
+        if (normalised.includes('_')) {
+          seenKeys.add(normalised.replace(/_/g, ''));
+        }
+      }
     });
 
-    const seenDistractors = new Set();
-    const unitVocab = Array.isArray(sentence.unitVocab) ? sentence.unitVocab : [];
-    unitVocab.forEach((word) => {
-      if (!word || typeof word !== 'string') {
+    unitWords.forEach((word, index) => {
+      if (!word) {
         return;
       }
-      if (tokens.includes(word)) {
+      const keys = Array.isArray(word.normalizedKeys) ? word.normalizedKeys : [];
+      const overlaps = keys.some((key) => key && seenKeys.has(key));
+      if (overlaps) {
         return;
       }
-      if (seenDistractors.has(word)) {
-        return;
-      }
-      seenDistractors.add(word);
-      tileEntries.push(createTileEntry(word, `extra-${word}`));
+      keys.forEach((key) => {
+        if (key) {
+          seenKeys.add(key);
+        }
+      });
+
+      const baseToken = word.token || word.canonicalToken || word.translit || word.si || word.en;
+      const tileToken = baseToken && typeof baseToken === 'string' ? baseToken : `word-${index}`;
+      tileEntries.push(createTileEntry(unit, tileToken, `extra-${index}`, word));
     });
 
     return shuffleArray(tileEntries);
@@ -228,7 +250,7 @@ function setupExercise(container, sentences, { onComplete } = {}) {
       setFeedback('✅ Correct!');
     } else {
       const correctSinhala = correct
-        .map((token) => getVocabEntry(token).si)
+        .map((token) => getMappingForToken(unit, token).si)
         .join(' ');
       setFeedback(`❌ Correct order: ${correctSinhala}`);
     }
@@ -267,12 +289,27 @@ function setupExercise(container, sentences, { onComplete } = {}) {
   setSentence(randomItem(sentences));
 }
 
-function createTileEntry(word, id) {
-  const mapping = getVocabEntry(word);
+function createTileEntry(unit, token, id, explicitWord = null) {
+  const mapping = getMappingForToken(unit, token, explicitWord);
+  const text = typeof token === 'string' && token ? token : mapping.translit || mapping.si || token || id;
   return {
     id,
-    text: word,
+    text,
     mapping,
     used: false,
+  };
+}
+
+function getMappingForToken(unit, token, explicitWord = null) {
+  const fallback = getVocabEntry(token);
+  const wordEntry = explicitWord || getWordEntryFromUnit(unit, token);
+  if (!wordEntry) {
+    return fallback;
+  }
+  const script = wordEntry.si || fallback.si || fallback.translit || token || '';
+  const transliteration = wordEntry.translit || wordEntry.token || fallback.translit || fallback.si || token || '';
+  return {
+    si: script,
+    translit: transliteration,
   };
 }

--- a/assets/Lessons/exercises/_shared/wordBankUtils.js
+++ b/assets/Lessons/exercises/_shared/wordBankUtils.js
@@ -1,3 +1,4 @@
+const WORDS_URL = new URL('../../sections/section-01-introductions/words.yaml', import.meta.url);
 const SENTENCES_URL = new URL('../../sections/section-01-introductions/sentences.yaml', import.meta.url);
 
 let cachedUnitsPromise = null;
@@ -19,104 +20,120 @@ export function randomItem(array) {
   return array[index] ?? null;
 }
 
-export async function loadSectionSentences() {
+export async function loadWordBankUnits() {
   if (!cachedUnitsPromise) {
-    cachedUnitsPromise = fetchSectionUnits();
+    cachedUnitsPromise = fetchWordBankUnits();
   }
   const units = await cachedUnitsPromise;
-  return units.map((unit) => ({
-    id: unit.id,
-    name: unit.name,
-    vocab: Array.isArray(unit.vocab) ? unit.vocab.slice() : [],
-    sentences: Array.isArray(unit.sentences)
-      ? unit.sentences.map((sentence) => ({ ...sentence }))
-      : [],
+  return units.map(cloneUnit);
+}
+
+export function resolveActiveUnit(units, providedUnitId) {
+  if (!Array.isArray(units) || units.length === 0) {
+    return null;
+  }
+
+  const candidates = [];
+  if (providedUnitId != null) {
+    candidates.push(providedUnitId);
+  }
+  candidates.push(...extractContextUnitCandidates());
+
+  for (const candidate of candidates) {
+    const match = findUnitByCandidate(units, candidate);
+    if (match) {
+      return match;
+    }
+  }
+
+  return units[0];
+}
+
+export function getUnitSentences(unit) {
+  if (!unit || !Array.isArray(unit.sentences)) {
+    return [];
+  }
+
+  // Placeholder for future lesson-level or per-sentence gating logic.
+  return unit.sentences.map((sentence) => ({
+    id: sentence.id,
+    text: sentence.text,
+    tokens: Array.isArray(sentence.tokens) ? sentence.tokens.slice() : [],
+    minUnit: sentence.minUnit ?? null,
+    unitId: unit.id,
   }));
 }
 
-async function fetchSectionUnits() {
-  if (typeof fetch !== 'function') {
-    throw new Error('Fetching sentences requires a browser environment.');
+export function getWordEntryFromUnit(unit, token) {
+  if (!unit || !token) {
+    return null;
   }
 
-  const response = await fetch(SENTENCES_URL, { cache: 'no-cache' });
-  if (!response.ok) {
+  const map = unit.wordMap || {};
+  const direct = map[token];
+  if (direct) {
+    return direct;
+  }
+
+  const baseKey = normaliseWordBankToken(token);
+  if (baseKey && map[baseKey]) {
+    return map[baseKey];
+  }
+
+  const withoutUnderscore = baseKey ? baseKey.replace(/_/g, '') : '';
+  if (withoutUnderscore && map[withoutUnderscore]) {
+    return map[withoutUnderscore];
+  }
+
+  if (baseKey && baseKey.includes('w')) {
+    const swapped = baseKey.replace(/w/g, 'v');
+    if (map[swapped]) {
+      return map[swapped];
+    }
+  }
+
+  if (baseKey && baseKey.includes('v')) {
+    const swapped = baseKey.replace(/v/g, 'w');
+    if (map[swapped]) {
+      return map[swapped];
+    }
+  }
+
+  return null;
+}
+
+export function normaliseWordBankToken(value) {
+  return createTokenKey(value);
+}
+
+async function fetchWordBankUnits() {
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetching word bank content requires a browser environment.');
+  }
+
+  const [wordsResponse, sentencesResponse] = await Promise.all([
+    fetch(WORDS_URL, { cache: 'no-cache' }),
+    fetch(SENTENCES_URL, { cache: 'no-cache' }),
+  ]);
+
+  if (!wordsResponse.ok) {
+    throw new Error('Failed to load section vocabulary.');
+  }
+  if (!sentencesResponse.ok) {
     throw new Error('Failed to load section sentences.');
   }
 
-  const text = await response.text();
-  return parseSectionYaml(text);
+  const [wordsText, sentencesText] = await Promise.all([
+    wordsResponse.text(),
+    sentencesResponse.text(),
+  ]);
+
+  const wordsUnits = parseWordsYaml(wordsText);
+  const sentenceUnits = parseSentencesYaml(sentencesText);
+  return mergeUnitContent(wordsUnits, sentenceUnits);
 }
 
-export function flattenSentences(units) {
-  if (!Array.isArray(units)) {
-    return [];
-  }
-
-  const sentences = [];
-  units.forEach((unit) => {
-    const vocab = Array.isArray(unit.vocab) ? unit.vocab : [];
-    const unitSentences = Array.isArray(unit.sentences) ? unit.sentences : [];
-    unitSentences.forEach((sentence) => {
-      sentences.push({
-        text: sentence.text || '',
-        tokens: Array.isArray(sentence.tokens) ? sentence.tokens.slice() : [],
-        minUnit: sentence.minUnit ?? null,
-        unit,
-        unitVocab: vocab,
-      });
-    });
-  });
-
-  return sentences;
-}
-
-export function determineUnitId(candidate) {
-  if (candidate == null) {
-    if (typeof window !== 'undefined') {
-      const lesson = window.BashaLanka && window.BashaLanka.currentLesson;
-      const detailUnit = lesson?.detail?.unitId ?? lesson?.meta?.unitId;
-      const numericDetail = Number(detailUnit);
-      if (!Number.isNaN(numericDetail) && numericDetail > 0) {
-        return numericDetail;
-      }
-    }
-    return 1;
-  }
-
-  const numeric = Number(candidate);
-  if (Number.isNaN(numeric) || numeric <= 0) {
-    return 1;
-  }
-  return numeric;
-}
-
-export function filterUnlockedSentences(sentences, unitId) {
-  if (!Array.isArray(sentences)) {
-    return [];
-  }
-
-  const resolvedUnitId = determineUnitId(unitId);
-  return sentences.filter((sentence) => {
-    if (!sentence) {
-      return false;
-    }
-
-    const { minUnit } = sentence;
-    if (minUnit == null || minUnit === '') {
-      return true;
-    }
-
-    const numeric = Number(minUnit);
-    if (Number.isNaN(numeric)) {
-      return true;
-    }
-
-    return numeric <= resolvedUnitId;
-  });
-}
-
-function parseSectionYaml(text) {
+function parseWordsYaml(text) {
   if (typeof text !== 'string' || !text.trim()) {
     return [];
   }
@@ -124,30 +141,190 @@ function parseSectionYaml(text) {
   const units = [];
   const lines = text.split(/\r?\n/);
   let currentUnit = null;
-  let currentSentence = null;
-  let mode = null;
 
   lines.forEach((line) => {
-    if (!line) {
-      return;
-    }
-
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) {
       return;
     }
 
-    if (trimmed.startsWith('- id:')) {
+    if (!line.startsWith('  ') && trimmed.endsWith(':')) {
+      currentUnit = null;
+      return;
+    }
+
+    if (line.startsWith('  ') && !line.startsWith('    ') && trimmed.endsWith(':')) {
+      const unitId = trimmed.slice(0, -1);
+      if (!unitId) {
+        currentUnit = null;
+        return;
+      }
+      currentUnit = { id: unitId, words: [] };
+      units.push(currentUnit);
+      return;
+    }
+
+    if (!currentUnit || !line.startsWith('    -')) {
+      return;
+    }
+
+    const entry = parseWordEntry(line);
+    if (entry) {
+      currentUnit.words.push(entry);
+    }
+  });
+
+  return units;
+}
+
+function parseWordEntry(line) {
+  const content = line.replace(/^\s*-\s*/, '');
+  if (!content) {
+    return null;
+  }
+
+  if (content.startsWith('{') && content.endsWith('}')) {
+    return createWordEntry(parseInlineObject(content));
+  }
+
+  const { value, comment } = splitValueAndComment(content);
+  const token = stripQuotes(value.trim());
+  if (!token) {
+    return null;
+  }
+
+  return createWordEntry({
+    token,
+    en: comment,
+  });
+}
+
+function parseInlineObject(text) {
+  const inner = text.replace(/^\{\s*|\s*\}$/g, '');
+  const result = {};
+  let buffer = '';
+  let depth = 0;
+
+  for (let i = 0; i < inner.length; i += 1) {
+    const char = inner[i];
+    if (char === '{' || char === '[') {
+      depth += 1;
+    } else if (char === '}' || char === ']') {
+      depth = Math.max(0, depth - 1);
+    }
+
+    if (char === ',' && depth === 0) {
+      processInlineSegment(buffer, result);
+      buffer = '';
+    } else {
+      buffer += char;
+    }
+  }
+
+  if (buffer.trim()) {
+    processInlineSegment(buffer, result);
+  }
+
+  return result;
+}
+
+function processInlineSegment(segment, target) {
+  if (!segment) {
+    return;
+  }
+  const parts = segment.split(':');
+  if (parts.length < 2) {
+    return;
+  }
+  const key = parts.shift().trim();
+  const value = parts.join(':').trim();
+  if (!key) {
+    return;
+  }
+  target[key] = stripQuotes(value);
+}
+
+function createWordEntry(data) {
+  const word = {
+    token: (data.token || data.id || '').trim(),
+    si: (data.si || data.script || '').trim(),
+    translit: (data.translit || data.transliteration || '').trim(),
+    en: (data.en || data.english || data.comment || '').trim(),
+  };
+
+  const canonicalCandidate =
+    word.token || word.translit || word.si || word.en || '';
+  word.canonicalToken = canonicalCandidate;
+
+  const keys = new Set();
+  addTokenCandidate(keys, word.token);
+  addTokenCandidate(keys, word.translit);
+  addTokenCandidate(keys, word.si);
+  addTokenCandidate(keys, word.en);
+  addTokenCandidate(keys, data.alias);
+
+  if (Array.isArray(data.aliases)) {
+    data.aliases.forEach((alias) => addTokenCandidate(keys, alias));
+  }
+
+  if (!keys.size) {
+    addTokenCandidate(keys, canonicalCandidate);
+  }
+
+  word.normalizedKeys = Array.from(keys);
+
+  if (!word.token && word.normalizedKeys.length > 0) {
+    word.token = word.normalizedKeys[0];
+  }
+
+  return word;
+}
+
+function splitValueAndComment(line) {
+  const hashIndex = line.indexOf('#');
+  if (hashIndex === -1) {
+    return { value: line, comment: '' };
+  }
+  return {
+    value: line.slice(0, hashIndex),
+    comment: line.slice(hashIndex + 1).trim(),
+  };
+}
+
+function parseSentencesYaml(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return [];
+  }
+
+  const units = [];
+  const lines = text.split(/\r?\n/);
+  let inUnits = false;
+  let currentUnit = null;
+  let currentSentence = null;
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+
+    if (!inUnits) {
+      if (trimmed === 'units:' || trimmed === 'units: []') {
+        inUnits = true;
+      }
+      return;
+    }
+
+    const indent = line.search(/\S/);
+
+    if (indent === 4 && trimmed.startsWith('- id:')) {
       const idValue = trimmed.replace(/^- id:\s*/, '').trim();
-      const parsedId = Number(idValue) || idValue;
       currentUnit = {
-        id: parsedId,
+        id: parseSentenceUnitId(idValue),
         name: '',
-        vocab: [],
         sentences: [],
       };
       units.push(currentUnit);
-      mode = null;
       currentSentence = null;
       return;
     }
@@ -156,91 +333,345 @@ function parseSectionYaml(text) {
       return;
     }
 
-    if (trimmed.startsWith('name:')) {
-      const value = trimmed.replace(/^name:\s*/, '').trim();
-      currentUnit.name = stripQuotes(value);
+    if (indent === 6 && trimmed.startsWith('name:')) {
+      currentUnit.name = stripQuotes(trimmed.replace(/^name:\s*/, ''));
       return;
     }
 
-    if (trimmed === 'vocab:') {
-      mode = 'vocab';
+    if (indent === 6 && trimmed === 'sentences:') {
       currentSentence = null;
       return;
     }
 
-    if (trimmed === 'sentences:') {
-      mode = 'sentences';
-      currentSentence = null;
+    if (indent === 8 && trimmed.startsWith('- text:')) {
+      const textValue = stripQuotes(trimmed.replace(/^- text:\s*/, ''));
+      currentSentence = {
+        id: null,
+        text: textValue,
+        tokens: [],
+        minUnit: null,
+      };
+      currentUnit.sentences.push(currentSentence);
       return;
     }
 
-    if (mode === 'vocab' && trimmed.startsWith('- ')) {
-      const vocabEntry = trimmed.replace(/^-\s*/, '');
-      const cleaned = stripComment(vocabEntry);
-      if (cleaned) {
-        currentUnit.vocab.push(cleaned);
-      }
+    if (!currentSentence) {
       return;
     }
 
-    if (mode === 'sentences') {
-      if (trimmed.startsWith('- text:')) {
-        const value = trimmed.replace(/^- text:\s*/, '');
-        const textValue = parseQuotedValue(value);
-        currentSentence = {
-          text: textValue,
-          tokens: [],
-          minUnit: null,
-        };
-        currentUnit.sentences.push(currentSentence);
-        return;
-      }
+    if (indent === 10 && trimmed.startsWith('tokens:')) {
+      const tokenText = trimmed.replace(/^tokens:\s*/, '');
+      currentSentence.tokens = parseArrayLiteral(tokenText);
+      return;
+    }
 
-      if (!currentSentence) {
-        return;
-      }
+    if (indent === 10 && trimmed.startsWith('minUnit:')) {
+      const value = trimmed.replace(/^minUnit:\s*/, '').trim();
+      const parsed = Number(value);
+      currentSentence.minUnit = Number.isNaN(parsed) ? value : parsed;
+      return;
+    }
 
-      if (trimmed.startsWith('tokens:')) {
-        const tokenText = trimmed.replace(/^tokens:\s*/, '');
-        currentSentence.tokens = parseArrayLiteral(tokenText);
-        return;
-      }
-
-      if (trimmed.startsWith('minUnit:')) {
-        const value = trimmed.replace(/^minUnit:\s*/, '').trim();
-        const parsed = Number(value);
-        currentSentence.minUnit = Number.isNaN(parsed) ? value : parsed;
-        return;
-      }
+    if (indent === 10 && trimmed.startsWith('id:')) {
+      const value = trimmed.replace(/^id:\s*/, '').trim();
+      const parsed = Number(value);
+      currentSentence.id = Number.isNaN(parsed) ? stripQuotes(value) : parsed;
     }
   });
 
   return units;
 }
 
-function parseQuotedValue(value) {
-  const trimmed = value.trim();
-  if (!trimmed) {
+function parseSentenceUnitId(value) {
+  const numeric = Number(value);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+  return stripQuotes(value);
+}
+
+function mergeUnitContent(wordUnits, sentenceUnits) {
+  const merged = [];
+  const sentenceByNumber = new Map();
+
+  sentenceUnits.forEach((unit) => {
+    const number = typeof unit.id === 'number' ? unit.id : extractUnitNumber(unit.id);
+    if (number != null) {
+      sentenceByNumber.set(number, unit);
+    }
+  });
+
+  const usedNumbers = new Set();
+
+  wordUnits.forEach((wordUnit) => {
+    const slug = wordUnit.id;
+    const number = extractUnitNumber(slug);
+    const sentenceUnit = number != null ? sentenceByNumber.get(number) : null;
+    if (number != null) {
+      usedNumbers.add(number);
+    }
+
+    const sentences = sentenceUnit ? sentenceUnit.sentences : [];
+    const name = sentenceUnit?.name || '';
+    merged.push(createUnitRecord({
+      id: slug,
+      number,
+      name,
+      words: wordUnit.words,
+      sentences,
+    }));
+  });
+
+  sentenceUnits.forEach((sentenceUnit) => {
+    const number = typeof sentenceUnit.id === 'number' ? sentenceUnit.id : extractUnitNumber(sentenceUnit.id);
+    if (number != null && usedNumbers.has(number)) {
+      return;
+    }
+    const slug = typeof sentenceUnit.id === 'string' && sentenceUnit.id.includes('unit-')
+      ? sentenceUnit.id
+      : `unit-${String(number ?? merged.length + 1).padStart(2, '0')}`;
+    merged.push(createUnitRecord({
+      id: slug,
+      number,
+      name: sentenceUnit.name || '',
+      words: [],
+      sentences: sentenceUnit.sentences,
+    }));
+  });
+
+  merged.sort((a, b) => {
+    const numberA = typeof a.number === 'number' ? a.number : Number.POSITIVE_INFINITY;
+    const numberB = typeof b.number === 'number' ? b.number : Number.POSITIVE_INFINITY;
+    if (numberA !== numberB) {
+      return numberA - numberB;
+    }
+    return (a.id || '').localeCompare(b.id || '');
+  });
+
+  return merged;
+}
+
+function createUnitRecord({ id, number, name, words, sentences }) {
+  const preparedWords = Array.isArray(words)
+    ? words.map((word) => ({
+        token: word.token || '',
+        si: word.si || '',
+        translit: word.translit || '',
+        en: word.en || '',
+        canonicalToken: word.canonicalToken || word.token || '',
+        normalizedKeys: Array.isArray(word.normalizedKeys) ? word.normalizedKeys.slice() : [],
+      }))
+    : [];
+
+  const wordMap = createWordMap(preparedWords);
+
+  const preparedSentences = Array.isArray(sentences)
+    ? sentences.map((sentence) => ({
+        id: sentence.id ?? null,
+        text: sentence.text || '',
+        tokens: Array.isArray(sentence.tokens) ? sentence.tokens.slice() : [],
+        minUnit: sentence.minUnit ?? null,
+      }))
+    : [];
+
+  return {
+    id,
+    number: typeof number === 'number' && !Number.isNaN(number) ? number : null,
+    name: name || '',
+    words: preparedWords,
+    wordMap,
+    sentences: preparedSentences,
+  };
+}
+
+function createWordMap(words) {
+  const map = Object.create(null);
+  words.forEach((word) => {
+    const candidates = Array.isArray(word.normalizedKeys) ? word.normalizedKeys : [];
+    candidates.forEach((candidate) => {
+      if (candidate && !map[candidate]) {
+        map[candidate] = word;
+      }
+    });
+
+    if (word.token) {
+      const lower = word.token.toLowerCase();
+      if (!map[lower]) {
+        map[lower] = word;
+      }
+    }
+
+    if (word.canonicalToken) {
+      const key = normaliseWordBankToken(word.canonicalToken);
+      if (key && !map[key]) {
+        map[key] = word;
+      }
+    }
+  });
+  return map;
+}
+
+function findUnitByCandidate(units, candidate) {
+  if (candidate == null) {
+    return null;
+  }
+
+  const stringCandidate = String(candidate).trim();
+  if (!stringCandidate) {
+    return null;
+  }
+
+  const lower = stringCandidate.toLowerCase();
+  const direct = units.find((unit) => unit.id && unit.id.toLowerCase() === lower);
+  if (direct) {
+    return direct;
+  }
+
+  const numeric = Number(stringCandidate);
+  if (!Number.isNaN(numeric) && numeric > 0) {
+    const match = units.find((unit) => unit.number === numeric);
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}
+
+function extractContextUnitCandidates() {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const context = window.BashaLanka?.currentLesson || {};
+  const detail = context.detail || {};
+  const meta = context.meta || {};
+  const candidates = [];
+
+  if (detail.unitId != null) {
+    candidates.push(detail.unitId);
+  }
+  if (detail.unitSlug != null) {
+    candidates.push(detail.unitSlug);
+  }
+  if (detail.unit != null) {
+    candidates.push(detail.unit);
+  }
+  if (meta.unitId != null) {
+    candidates.push(meta.unitId);
+  }
+  if (meta.unitSlug != null) {
+    candidates.push(meta.unitSlug);
+  }
+
+  return candidates;
+}
+
+function extractUnitNumber(value) {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return value;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+  const numeric = Number(text);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+  const match = text.match(/unit-(\d+)/i);
+  if (match) {
+    return Number(match[1]);
+  }
+  return null;
+}
+
+function cloneUnit(unit) {
+  if (!unit) {
+    return null;
+  }
+  const words = Array.isArray(unit.words)
+    ? unit.words.map((word) => ({
+        token: word.token,
+        si: word.si,
+        translit: word.translit,
+        en: word.en,
+        canonicalToken: word.canonicalToken,
+        normalizedKeys: Array.isArray(word.normalizedKeys) ? word.normalizedKeys.slice() : [],
+      }))
+    : [];
+  const sentences = Array.isArray(unit.sentences)
+    ? unit.sentences.map((sentence) => ({
+        id: sentence.id,
+        text: sentence.text,
+        tokens: Array.isArray(sentence.tokens) ? sentence.tokens.slice() : [],
+        minUnit: sentence.minUnit,
+      }))
+    : [];
+  return {
+    id: unit.id,
+    number: unit.number,
+    name: unit.name,
+    words,
+    wordMap: createWordMap(words),
+    sentences,
+  };
+}
+
+function addTokenCandidate(collection, value) {
+  if (value == null) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => addTokenCandidate(collection, item));
+    return;
+  }
+
+  const key = createTokenKey(value);
+  if (!key) {
+    return;
+  }
+
+  collection.add(key);
+
+  if (key.includes('v')) {
+    collection.add(key.replace(/v/g, 'w'));
+  }
+  if (key.includes('w')) {
+    collection.add(key.replace(/w/g, 'v'));
+  }
+  if (key.includes('_')) {
+    collection.add(key.replace(/_/g, ''));
+  }
+}
+
+function createTokenKey(value) {
+  if (value == null) {
     return '';
   }
-  const firstChar = trimmed[0];
-  const lastChar = trimmed[trimmed.length - 1];
-  if (firstChar === '"' && lastChar === '"') {
-    try {
-      return JSON.parse(trimmed);
-    } catch (error) {
-      return trimmed.slice(1, -1);
-    }
+  const text = String(value).trim();
+  if (!text) {
+    return '';
   }
-  if (firstChar === '\'' && lastChar === '\'') {
-    const inner = trimmed.slice(1, -1);
-    try {
-      return JSON.parse(`"${inner.replace(/"/g, '\\"')}"`);
-    } catch (error) {
-      return inner;
-    }
-  }
-  return stripQuotes(trimmed);
+  const normalized = text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/["'’“”‘]/g, '')
+    .replace(/\[[^\]]*\]/g, '')
+    .replace(/\([^)]*\)/g, '')
+    .replace(/\{[^}]*\}/g, '')
+    .replace(/&/g, 'and');
+
+  const replaced = normalized
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  return replaced.toLowerCase();
 }
 
 function parseArrayLiteral(value) {
@@ -249,7 +680,8 @@ function parseArrayLiteral(value) {
     return [];
   }
   try {
-    return JSON.parse(trimmed);
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : [];
   } catch (error) {
     return trimmed
       .replace(/^[\[]|[\]]$/g, '')
@@ -259,27 +691,28 @@ function parseArrayLiteral(value) {
   }
 }
 
-function stripComment(value) {
-  const noComment = value.replace(/\s+#.*$/, '');
-  return stripQuotes(noComment.trim());
-}
-
 function stripQuotes(value) {
-  if (!value) {
+  if (value == null) {
     return '';
   }
-  const trimmed = value.trim();
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith('\'') && trimmed.endsWith('\''))) {
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+  const firstChar = trimmed[0];
+  const lastChar = trimmed[trimmed.length - 1];
+  if ((firstChar === '"' && lastChar === '"') || (firstChar === '\'' && lastChar === '\'')) {
     return trimmed.slice(1, -1);
   }
   return trimmed;
 }
 
 export default {
-  loadSectionSentences,
-  flattenSentences,
+  loadWordBankUnits,
+  resolveActiveUnit,
+  getUnitSentences,
+  getWordEntryFromUnit,
+  normaliseWordBankToken,
   shuffleArray,
   randomItem,
-  filterUnlockedSentences,
-  determineUnitId,
 };


### PR DESCRIPTION
## Summary
- load and merge section vocabulary and sentence data from the new YAML sources
- update the Sinhala and English word bank exercises to select the active unit and build tiles from unit-specific words
- add token normalisation and lookup helpers to support dynamic Sinhala word rendering

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68df23cb0db8833095aca72c2056f0ab