### PR TITLE
Add fresh Word Bank English exercise

### DIFF
--- a/app.js
+++ b/app.js
@@ -522,6 +522,12 @@ const LESSON_SIMULATOR_EXERCISES = [
     loader: () => loadExerciseModule('Dialogue/index.js')
   },
   {
+    id: 'wordbank-english',
+    label: 'Word Bank (Sinhala → English)',
+    description: 'Rebuild the English sentence from Sinhala prompts.',
+    loader: () => loadExerciseModule('WordBankEnglish/index.js')
+  },
+  {
     id: 'speak',
     label: 'Speaking',
     description: 'Practice pronouncing Sinhala aloud.',
@@ -913,11 +919,189 @@ const DebugTools = (() => {
     startButton: null,
     selectedExercises: new Set()
   };
-  const fallbackLessonsCache = {
+  const courseLessonsCache = {
     promise: null,
     sections: []
   };
   let documentClickHandler = null;
+
+  function isReadyStatus(value) {
+    if (value === null || value === undefined) return true;
+    const normalized = String(value).trim().toLowerCase();
+    if (!normalized) return true;
+    return normalized === 'ready' || normalized === 'published';
+  }
+
+  function stripQuotes(value = '') {
+    return value.replace(/^['"]+|['"]+$/g, '');
+  }
+
+  function parseUnitOverview(text = '') {
+    const result = {
+      lessonIds: [],
+      lessonDetails: []
+    };
+
+    if (!text) {
+      return result;
+    }
+
+    const frontMatterMatch = text.match(/^---\s*([\s\S]*?)\n---\s*/);
+    let body = text;
+
+    if (frontMatterMatch) {
+      const frontMatter = frontMatterMatch[1] || '';
+      body = text.slice(frontMatterMatch[0].length);
+      frontMatter.split(/\r?\n/).forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        if (/^lessons:/i.test(trimmed)) {
+          const listMatch = trimmed.match(/lessons:\s*\[([^\]]*)\]/i);
+          if (listMatch) {
+            const items = listMatch[1]
+              .split(',')
+              .map(entry => stripQuotes(entry.trim()))
+              .filter(Boolean);
+            result.lessonIds = items;
+          }
+        }
+      });
+    }
+
+    body.split(/\r?\n/).forEach(line => {
+      if (!line) return;
+      const plain = line.replace(/\*\*/g, '').trim();
+      if (!plain.startsWith('-')) return;
+      const withoutBullet = plain.replace(/^-+\s*/, '');
+      const lessonMatch = withoutBullet.match(/^Lesson\s+(\d+)(.*)$/i);
+      if (!lessonMatch) return;
+      const number = parseInt(lessonMatch[1], 10);
+      let remainder = (lessonMatch[2] || '').trim();
+      remainder = remainder.replace(/^[:—–-]+\s*/, '').trim();
+      result.lessonDetails.push({
+        number: Number.isFinite(number) ? number : result.lessonDetails.length + 1,
+        title: remainder
+      });
+    });
+
+    return result;
+  }
+
+  function ensureCourseLessons() {
+    if (courseLessonsCache.sections.length) {
+      return Promise.resolve(courseLessonsCache.sections);
+    }
+
+    if (courseLessonsCache.promise) {
+      return courseLessonsCache.promise;
+    }
+
+    const load = (async () => {
+      try {
+        const mapPath = resolveAssetPath('assets/Lessons/course.map.json');
+        const res = await fetch(mapPath, { cache: 'no-cache' });
+        if (!res.ok) {
+          throw new Error('Failed to load course map');
+        }
+        const map = await res.json();
+        const sections = Array.isArray(map && map.sections) ? map.sections : [];
+        const readySections = [];
+
+        for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex += 1) {
+          const section = sections[sectionIndex] || {};
+          if (!isReadyStatus(section.status)) {
+            continue;
+          }
+          const sectionId = section.id || `section-${sectionIndex + 1}`;
+          const sectionNumber = typeof section.number === 'number'
+            ? section.number
+            : sectionIndex + 1;
+          const rawSectionTitle = typeof section.title === 'string' ? section.title.trim() : '';
+          const sectionTitle = rawSectionTitle || `Section ${sectionNumber}`;
+          const units = Array.isArray(section.units) ? section.units : [];
+          const readyUnits = [];
+
+          for (let unitIndex = 0; unitIndex < units.length; unitIndex += 1) {
+            const unit = units[unitIndex] || {};
+            if (!isReadyStatus(unit.status)) {
+              continue;
+            }
+            const unitId = unit.id || `unit-${unitIndex + 1}`;
+            const unitNumber = typeof unit.number === 'number'
+              ? unit.number
+              : unitIndex + 1;
+            const rawUnitTitle = typeof unit.title === 'string' ? unit.title.trim() : '';
+            const unitTitle = rawUnitTitle || `Unit ${unitNumber}`;
+            const pathRef = normaliseRelativeAssetPath((unit.path_ref || `sections/${sectionId}/units/${unitId}`).trim());
+            const overviewPath = resolveAssetPath(`assets/Lessons/${pathRef}/overview.md`);
+            let overviewText = '';
+
+            try {
+              const overviewRes = await fetch(overviewPath, { cache: 'no-cache' });
+              if (!overviewRes.ok) {
+                continue;
+              }
+              overviewText = await overviewRes.text();
+            } catch (err) {
+              console.warn('Failed to load unit overview', unitId, err);
+              continue;
+            }
+
+            const overviewData = parseUnitOverview(overviewText);
+            const lessonCount = Math.max(overviewData.lessonIds.length, overviewData.lessonDetails.length);
+            if (!lessonCount) {
+              continue;
+            }
+
+            const lessons = [];
+            for (let lessonIndex = 0; lessonIndex < lessonCount; lessonIndex += 1) {
+              const rawId = overviewData.lessonIds[lessonIndex] || `lesson-${String(lessonIndex + 1).padStart(2, '0')}`;
+              const lessonId = stripQuotes(rawId);
+              if (!lessonId) {
+                continue;
+              }
+              const detail = overviewData.lessonDetails[lessonIndex] || {};
+              const lessonNumber = Number.isFinite(detail.number) ? detail.number : lessonIndex + 1;
+              const title = (detail.title || '').trim();
+              lessons.push({
+                id: lessonId,
+                number: lessonNumber,
+                title
+              });
+            }
+
+            if (!lessons.length) {
+              continue;
+            }
+
+            readyUnits.push({
+              id: unitId,
+              number: unitNumber,
+              title: unitTitle,
+              lessons
+            });
+          }
+
+          if (readyUnits.length) {
+            readySections.push({
+              id: sectionId,
+              number: sectionNumber,
+              title: sectionTitle,
+              units: readyUnits
+            });
+          }
+        }
+
+        courseLessonsCache.sections = readySections;
+        return readySections;
+      } finally {
+        courseLessonsCache.promise = null;
+      }
+    })();
+
+    courseLessonsCache.promise = load;
+    return load;
+  }
 
   function appendControl(entry){
     if(!controlsContainer) return;
@@ -1030,74 +1214,60 @@ const DebugTools = (() => {
     closeExerciseMenu();
   }
 
-  function ensureFallbackLessons(){
-    if(fallbackLessonsCache.sections.length) return Promise.resolve(fallbackLessonsCache.sections);
-    if(fallbackLessonsCache.promise) return fallbackLessonsCache.promise;
-    const load = (async () => {
-      const collected = [];
-      for(let index = 1; index <= 50; index += 1){
-        const slug = `section-${index}`;
-        const path = resolveAssetPath(`assets/sections/${slug}/units.json`);
-        try{
-          const res = await fetch(path, { cache: 'no-cache' });
-          if(!res.ok){
-            break;
-          }
-          const data = await res.json();
-          if(data){
-            collected.push(data);
-          }
-        }catch(err){
-          console.warn('debug: failed to load lesson data for simulator', err);
-          break;
-        }
-      }
-      fallbackLessonsCache.sections = collected;
-      fallbackLessonsCache.promise = null;
-      return collected;
-    })();
-    fallbackLessonsCache.promise = load;
-    return load;
-  }
-
   function populateLessons(){
     if(!simulatorState.lessonSelect) return;
     const select = simulatorState.lessonSelect;
-    const learn = window.__LEARN__;
     select.disabled = true;
     select.innerHTML = '<option value="">Loading…</option>';
     lessonOptionMap.clear();
     updateStartButtonState();
     const buildOptions = sections => {
       const options = [];
-      sections.forEach((section, sectionIndex) => {
-        const sectionNumber = section.number || sectionIndex + 1;
+      sections.forEach(section => {
+        const sectionNumber = section.number || 0;
         const sectionTitle = section.title || (sectionNumber ? `Section ${sectionNumber}` : 'Section');
         const units = Array.isArray(section.units) ? section.units : [];
-        units.forEach((unit, unitIndex) => {
+        units.forEach(unit => {
           const unitId = unit.id || '';
-          const unitTitle = unit.title || `Unit ${unitIndex + 1}`;
-          const unitNumber = unit.number || unitIndex + 1;
+          if(!unitId) return;
+          const unitNumber = unit.number || 0;
+          const unitTitle = unit.title || (unitNumber ? `Unit ${unitNumber}` : 'Unit');
           const lessons = Array.isArray(unit.lessons) ? unit.lessons : [];
           lessons.forEach((lesson, index) => {
             const lessonId = lesson && lesson.id ? lesson.id : '';
             if(!lessonId) return;
-            const key = [sectionNumber, unitId, lessonId, lesson.skillId || '', lesson.levelId || ''].join('|');
-            const lessonTitle = lesson.title || `Lesson ${index + 1}`;
-            const textParts = [
-              sectionNumber ? `Section ${sectionNumber}` : sectionTitle,
-              unitTitle,
-              lessonTitle
-            ].filter(Boolean);
+            const lessonNumber = lesson.number || index + 1;
+            const lessonTitleRaw = typeof lesson.title === 'string' ? lesson.title.trim() : '';
+            const hasTitle = lessonTitleRaw.length > 0;
+            const lessonTitleText = hasTitle
+              ? `Lesson ${lessonNumber}: ${lessonTitleRaw}`
+              : `Lesson ${lessonNumber}`;
+            const textParts = [];
+            if(sectionNumber){
+              textParts.push(`Section ${sectionNumber}`);
+              if(sectionTitle && sectionTitle !== `Section ${sectionNumber}`){
+                textParts.push(sectionTitle);
+              }
+            }else if(sectionTitle){
+              textParts.push(sectionTitle);
+            }
+            if(unitNumber){
+              textParts.push(`Unit ${unitNumber}: ${unitTitle}`);
+            }else if(unitTitle){
+              textParts.push(unitTitle);
+            }
+            textParts.push(lessonTitleText);
+            const key = [section.id || sectionNumber, unitId, lessonId].join('|');
             lessonOptionMap.set(key, {
+              sectionId: section.id || '',
               sectionNumber,
               sectionTitle,
               unitId,
               unitNumber,
               unitTitle,
               lessonId,
-              lessonTitle,
-              lessonIndex: index + 1,
+              lessonTitle: lessonTitleText,
+              lessonIndex: lessonNumber,
               totalLessons: lessons.length || 0,
               skillId: lesson.skillId || '',
               levelId: lesson.levelId || ''
@@ -1116,21 +1286,7 @@ const DebugTools = (() => {
       updateStartButtonState();
     };
 
-    if(learn && typeof learn.ensureSections === 'function'){
-      learn.ensureSections().then(() => {
-        const snapshot = typeof learn.getSectionsSnapshot === 'function' ? learn.getSectionsSnapshot() : [];
-        buildOptions(snapshot);
-      }).catch(() => {
-        ensureFallbackLessons().then(buildOptions).catch(() => {
-          select.innerHTML = '<option value="">Failed to load lessons</option>';
-          select.disabled = true;
-          updateStartButtonState();
-        });
-      });
-      return;
-    }
-
-    ensureFallbackLessons().then(buildOptions).catch(() => {
+    ensureCourseLessons().then(buildOptions).catch(() => {
       select.innerHTML = '<option value="">Failed to load lessons</option>';
       select.disabled = true;
       updateStartButtonState();

--- a/assets/Lessons/exercises/WordBankEnglish/index.js
+++ b/assets/Lessons/exercises/WordBankEnglish/index.js
@@ -1,0 +1,328 @@
+import { ensureStylesheet } from '../_shared/utils.js';
+import {
+  loadSectionSentences,
+  flattenSentences,
+  filterUnlockedSentences,
+  randomItem,
+  shuffleArray,
+} from '../_shared/wordBankUtils.js';
+import { getVocabEntry } from '../_shared/vocabMap.js';
+
+const DEFAULT_CONTAINER_SELECTOR = '[data-exercise="wordbank-english"]';
+const STYLESHEET_ID = 'wordbank-english-styles';
+
+export default async function initWordBankEnglishExercise(options = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('WordBankEnglish requires a browser environment.');
+  }
+
+  const {
+    target = document.querySelector(DEFAULT_CONTAINER_SELECTOR),
+    onComplete,
+    unitId: providedUnitId,
+  } = options;
+
+  if (!target) {
+    throw new Error('WordBankEnglish target element not found.');
+  }
+
+  ensureStylesheet(STYLESHEET_ID, './styles.css', { baseUrl: import.meta.url });
+
+  target.innerHTML = '<p>Loading sentences…</p>';
+
+  try {
+    const units = await loadSectionSentences();
+    const sentences = filterUnlockedSentences(flattenSentences(units), providedUnitId);
+
+    if (!sentences.length) {
+      target.innerHTML = '<p>No sentences available.</p>';
+      return;
+    }
+
+    setupExercise(target, sentences, { onComplete });
+  } catch (error) {
+    console.error('Failed to initialise WordBankEnglish exercise', error);
+    target.innerHTML = '<p>Unable to load sentences.</p>';
+  }
+}
+
+function setupExercise(container, sentences, { onComplete } = {}) {
+  const wrapper = document.createElement('section');
+  wrapper.className = 'wordbank wordbank--english';
+
+  const title = document.createElement('h2');
+  title.className = 'wordbank__title';
+  title.textContent = 'Word Bank — English';
+  wrapper.appendChild(title);
+
+  const promptWrapper = document.createElement('div');
+  promptWrapper.className = 'wordbank__prompt';
+  wrapper.appendChild(promptWrapper);
+
+  const instructions = document.createElement('p');
+  instructions.className = 'wordbank__instructions';
+  instructions.textContent = 'Tap the English tiles to build the translation.';
+  wrapper.appendChild(instructions);
+
+  const tilesContainer = document.createElement('div');
+  tilesContainer.className = 'wordbank__tiles';
+  wrapper.appendChild(tilesContainer);
+
+  const answerLabel = document.createElement('p');
+  answerLabel.className = 'wordbank__answer-label';
+  answerLabel.textContent = 'Your answer:';
+  wrapper.appendChild(answerLabel);
+
+  const answerContainer = document.createElement('div');
+  answerContainer.className = 'wordbank__answer';
+  wrapper.appendChild(answerContainer);
+
+  const feedback = document.createElement('p');
+  feedback.className = 'wordbank__feedback';
+  feedback.setAttribute('role', 'status');
+  feedback.setAttribute('aria-live', 'polite');
+  wrapper.appendChild(feedback);
+
+  const actions = document.createElement('div');
+  actions.className = 'wordbank__actions';
+  wrapper.appendChild(actions);
+
+  const checkBtn = document.createElement('button');
+  checkBtn.type = 'button';
+  checkBtn.textContent = 'Check';
+  checkBtn.disabled = true;
+  actions.appendChild(checkBtn);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.textContent = 'Clear';
+  actions.appendChild(clearBtn);
+
+  const nextBtn = document.createElement('button');
+  nextBtn.type = 'button';
+  nextBtn.textContent = 'Next';
+  actions.appendChild(nextBtn);
+
+  if (typeof onComplete === 'function') {
+    const finishBtn = document.createElement('button');
+    finishBtn.type = 'button';
+    finishBtn.textContent = 'Finish';
+    finishBtn.addEventListener('click', () => onComplete());
+    actions.appendChild(finishBtn);
+  }
+
+  container.innerHTML = '';
+  container.appendChild(wrapper);
+
+  let currentSentence = null;
+  let tiles = [];
+  let answer = [];
+  let correctTiles = [];
+
+  function setSentence(sentence) {
+    currentSentence = sentence;
+    if (!sentence) {
+      promptWrapper.innerHTML = '';
+      tilesContainer.innerHTML = '';
+      answerContainer.innerHTML = '';
+      setFeedback('');
+      checkBtn.disabled = true;
+      return;
+    }
+
+    renderSinhalaPrompt(promptWrapper, Array.isArray(sentence.tokens) ? sentence.tokens : []);
+    correctTiles = splitEnglishIntoTiles(sentence.text);
+    tiles = shuffleArray(
+      correctTiles.map((text, index) => ({
+        id: `tile-${index}`,
+        text,
+        used: false,
+      })),
+    );
+    answer = [];
+
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function updateTiles() {
+    tilesContainer.innerHTML = '';
+    tiles.forEach((tile) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'wordbank__tile';
+      button.textContent = tile.text;
+      button.disabled = tile.used;
+      button.addEventListener('click', () => handleTileSelect(tile));
+      tilesContainer.appendChild(button);
+    });
+  }
+
+  function handleTileSelect(tile) {
+    if (!tile || tile.used) {
+      return;
+    }
+    tile.used = true;
+    answer.push(tile);
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function updateAnswer() {
+    answerContainer.innerHTML = '';
+
+    if (!answer.length) {
+      const placeholder = document.createElement('span');
+      placeholder.className = 'wordbank__answer-placeholder';
+      placeholder.textContent = 'Tap tiles to build your translation';
+      answerContainer.appendChild(placeholder);
+      checkBtn.disabled = true;
+      return;
+    }
+
+    answer.forEach((tile, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'wordbank__answer-tile';
+      button.textContent = tile.text;
+      button.addEventListener('click', () => removeTile(index));
+      answerContainer.appendChild(button);
+    });
+
+    checkBtn.disabled = answer.length === 0;
+  }
+
+  function removeTile(index) {
+    const [removed] = answer.splice(index, 1);
+    if (removed) {
+      const tile = tiles.find((entry) => entry.id === removed.id);
+      if (tile) {
+        tile.used = false;
+      }
+    }
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function handleCheck() {
+    if (!currentSentence) {
+      return;
+    }
+    const attempt = answer.map((entry) => entry.text);
+    const isCorrect = arraysEqual(attempt, correctTiles);
+
+    if (isCorrect) {
+      setFeedback('✅ Correct!');
+    } else {
+      setFeedback(`❌ Correct order: ${formatTiles(correctTiles)}`);
+    }
+  }
+
+  function setFeedback(message) {
+    feedback.textContent = message || '';
+  }
+
+  function handleClear() {
+    tiles.forEach((tile) => {
+      tile.used = false;
+    });
+    answer = [];
+    updateTiles();
+    updateAnswer();
+    setFeedback('');
+  }
+
+  function handleNext() {
+    if (!sentences.length) {
+      return;
+    }
+
+    let nextSentence = randomItem(sentences);
+    if (sentences.length > 1) {
+      let guard = 0;
+      while (nextSentence === currentSentence && guard < 8) {
+        nextSentence = randomItem(sentences);
+        guard += 1;
+      }
+    }
+
+    handleClear();
+    setSentence(nextSentence);
+  }
+
+  checkBtn.addEventListener('click', handleCheck);
+  clearBtn.addEventListener('click', handleClear);
+  nextBtn.addEventListener('click', handleNext);
+
+  setSentence(randomItem(sentences));
+}
+
+function renderSinhalaPrompt(container, tokens) {
+  container.innerHTML = '';
+  if (!Array.isArray(tokens) || !tokens.length) {
+    return;
+  }
+
+  tokens.forEach((token) => {
+    const entry = getVocabEntry(token);
+    const wrapper = document.createElement('span');
+    wrapper.className = 'wordbank__prompt-token';
+
+    const script = document.createElement('span');
+    script.className = 'wordbank__prompt-si';
+    script.textContent = entry.si || token;
+    script.lang = 'si';
+
+    const translit = document.createElement('span');
+    translit.className = 'wordbank__prompt-translit';
+    translit.textContent = entry.translit || '';
+    translit.lang = 'si-Latn';
+
+    wrapper.appendChild(script);
+    if (translit.textContent) {
+      wrapper.appendChild(translit);
+    }
+
+    container.appendChild(wrapper);
+  });
+}
+
+function splitEnglishIntoTiles(text) {
+  if (typeof text !== 'string') {
+    return [];
+  }
+
+  const matches = text.match(/\{[^}]+\}|\[[^\]]+\]|[A-Za-z0-9'’\-]+|[.,!?]/g);
+  if (!matches) {
+    return [];
+  }
+
+  return matches;
+}
+
+function formatTiles(tokens) {
+  return tokens.reduce((acc, token) => {
+    if (!acc) {
+      return token;
+    }
+    if (/^[.,!?]$/.test(token)) {
+      return `${acc}${token}`;
+    }
+    return `${acc} ${token}`;
+  }, '');
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/assets/Lessons/exercises/WordBankEnglish/styles.css
+++ b/assets/Lessons/exercises/WordBankEnglish/styles.css
@@ -1,0 +1,179 @@
+.wordbank {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(7, 16, 32, 0.92);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  color: #f5f8ff;
+  font-family: 'Inter', system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.wordbank__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-align: center;
+}
+
+.wordbank__prompt {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.wordbank__prompt-token {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 64px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(19, 35, 70, 0.9);
+  border: 1px solid rgba(80, 112, 192, 0.4);
+}
+
+.wordbank__prompt-si {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.wordbank__prompt-translit {
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  color: #b7c4dd;
+}
+
+.wordbank__instructions {
+  margin: 0 auto;
+  max-width: 460px;
+  text-align: center;
+  font-size: 0.95rem;
+  color: #b7c4dd;
+}
+
+.wordbank__tiles {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.wordbank__tile {
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(92, 125, 210, 0.45);
+  background: rgba(18, 31, 64, 0.95);
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+}
+
+.wordbank__tile:not(:disabled):hover,
+.wordbank__tile:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  border-color: #66d9ff;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}
+
+.wordbank__tile:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.wordbank__answer-label {
+  margin: 0;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #9fafc8;
+}
+
+.wordbank__answer {
+  min-height: 3rem;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(92, 125, 210, 0.4);
+  background: rgba(12, 21, 44, 0.85);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.wordbank__answer-placeholder {
+  font-style: italic;
+  color: #9fafc8;
+}
+
+.wordbank__answer-tile {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: #66d9ff;
+  color: #052044;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  transition: transform 0.16s ease, background 0.16s ease, box-shadow 0.16s ease;
+}
+
+.wordbank__answer-tile:hover,
+.wordbank__answer-tile:focus-visible {
+  transform: translateY(-1px);
+  background: #48c4f0;
+  color: #f5f8ff;
+}
+
+.wordbank__feedback {
+  min-height: 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: #b7c4dd;
+}
+
+.wordbank__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.wordbank__actions button {
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(92, 125, 210, 0.45);
+  background: rgba(17, 30, 58, 0.95);
+  color: #f5f8ff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.wordbank__actions button:hover,
+.wordbank__actions button:focus-visible {
+  transform: translateY(-1px);
+  border-color: #66d9ff;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
+
+@media (max-width: 540px) {
+  .wordbank {
+    padding: 1.25rem;
+    border-radius: 1rem;
+  }
+
+  .wordbank__prompt-token {
+    min-width: 56px;
+    padding: 0.45rem 0.6rem;
+  }
+
+  .wordbank__prompt-si {
+    font-size: 1.2rem;
+  }
+}

--- a/assets/Lessons/exercises/_shared/vocabMap.js
+++ b/assets/Lessons/exercises/_shared/vocabMap.js
@@ -4,6 +4,8 @@ export const vocabMap = {
   kohomada: { si: 'කොහොමද', translit: 'kohomada' },
   mama: { si: 'මම', translit: 'mama' },
   hondai: { si: 'හොඳයි', translit: 'hondai' },
+  owu: { si: 'ඔව්', translit: 'owu' },
+  nae: { si: 'නෑ', translit: 'nae' },
   ohu: { si: 'ඔහු', translit: 'ohu' },
   eya: { si: 'ඇය', translit: 'eya' },
   mage: { si: 'මගේ', translit: 'mage' },


### PR DESCRIPTION
## Summary
- rebuild the Word Bank English exercise with a simplified prompt, tile selection flow, and finish controls
- streamline the shared word bank utilities to load section sentences and expose basic helpers
- refresh the Word Bank styling to match the new prompt tokens, tiles, and answer area layout

## Testing
- node -e "import('./assets/Lessons/exercises/_shared/wordBankUtils.js').then(()=>console.log('utils ok')).catch(err=>{console.error(err);process.exit(1);});"
- node -e "import('./assets/Lessons/exercises/WordBankEnglish/index.js').then(()=>console.log('wordbank ok')).catch(err=>{console.error(err);process.exit(1);});"

------
https://chatgpt.com/codex/tasks/task_e_68df3079f0c48330a6be17d75a3a60df