### PR TITLE
Update Sinhala intro content and add unit lesson plans

### DIFF
--- a/assets/Lessons/sections/section-01-introductions/sentences.yaml
+++ b/assets/Lessons/sections/section-01-introductions/sentences.yaml
@@ -4,37 +4,51 @@
 
 Section01:
   title: "Introductions & Essentials"
-  description: "Greetings, introductions, origin, feelings, and polite expressions."
+  description: "Greetings, introductions, origin, feelings, age, and communication."
   units:
 
     - id: 1
-      name: "Greetings & Basics"
+      name: "Pronouns & Greetings"
       vocab:
-        - ayubowan
-        - oyaata
-        - kohomada
         - mama
-        - hondai
+        - oya
+        - ohu
+        - eya
+        - api
+        - owun
+        - ayubowan
+        - kohoma
+        - da
+        - hondayi
+        - honda
+        - saniipen
         - sthuthiyi
         - owu
         - nae
-        - karunakar
+        - naehae
+        - karunakara
         - samavenna
       sentences:
+        - text: "Hello!"
+          tokens: ["ayubowan"]
+          minUnit: 1
         - text: "Hello, how are you?"
-          tokens: ["ayubowan", "oyaata", "kohomada"]
+          tokens: ["ayubowan", "oya", "kohoma", "da"]
           minUnit: 1
-        - text: "I am fine, thank you."
-          tokens: ["mama", "hondai", "sthuthiyi"]
+        - text: "I am fine."
+          tokens: ["mama", "hondayi"]
           minUnit: 1
-        - text: "Yes."
-          tokens: ["owu"]
+        - text: "No, I am not fine."
+          tokens: ["nae", "mama", "honda", "naehae"]
           minUnit: 1
-        - text: "No."
-          tokens: ["nae"]
+        - text: "Are you well?"
+          tokens: ["oya", "saniipen", "da"]
+          minUnit: 1
+        - text: "Thank you."
+          tokens: ["sthuthiyi"]
           minUnit: 1
         - text: "Please."
-          tokens: ["karunakar"]
+          tokens: ["karunakara"]
           minUnit: 1
         - text: "Sorry."
           tokens: ["samavenna"]
@@ -44,239 +58,126 @@ Section01:
       name: "Introducing Yourself"
       vocab:
         - mage
-        - nama
         - oyaage
-        - mokakda
-        - haduwime
+        - obage
+        - ohuge
+        - eyage
+        - ape
+        - owunge
+        - nama
+        - mokak
+        - da
+        - kiyanne
+        - kiyanawa
+        - me
+        - yalua
+        - yaluwō
+        - oyata
+        - oyatat
+        - handuwima
         - sathutak
+        - sthuthiyi
+        - hondin
       sentences:
         - text: "My name is {name}."
           tokens: ["mage", "nama", "{name}"]
           minUnit: 2
         - text: "What is your name?"
-          tokens: ["oyaage", "nama", "mokakda"]
+          tokens: ["oyaage", "nama", "mokak", "da"]
           minUnit: 2
         - text: "Nice to meet you."
-          tokens: ["oyaata", "haduwime", "sathutak"]
+          tokens: ["oyata", "handuwima", "sathutak"]
           minUnit: 2
-
-    - id: 3
-      name: "Where You're From"
-      vocab:
-        - mama
-        - oya
-        - kohenda
-        - rata
-        - gena
-        - Sri_Lanka
-        - Australia
-      sentences:
-        - text: "I am from Sri Lanka."
-          tokens: ["mama", "Sri_Lanka", "gena"]
-          minUnit: 3
-        - text: "Where are you from?"
-          tokens: ["oya", "kohenda"]
-          minUnit: 3
-        - text: "My country is Australia."
-          tokens: ["mage", "rata", "Australia"]
-          minUnit: 3
-
-    - id: 4
-      name: "Feelings & Health"
-      vocab:
-        - mama
-        - oya
-        - sanipen
-        - da
-        - hondai
-        - naehae
-        - santhoshayi
-        - dukthayi
-      sentences:
-        - text: "Are you well?"
-          tokens: ["oya", "sanipen", "da"]
-          minUnit: 4
-        - text: "I am well."
-          tokens: ["mama", "sanipen"]
-          minUnit: 4
-        - text: "I am not well."
-          tokens: ["mama", "hondai", "naehae"]
-          minUnit: 4
-        - text: "I am happy."
-          tokens: ["mama", "santhoshayi"]
-          minUnit: 4
-        - text: "I am sad."
-          tokens: ["mama", "dukthayi"]
-          minUnit: 4
-
-    - id: 5
-      name: "Politeness & Farewells"
-      vocab:
-        - suba
-        - udek
-        - raththiyek
-        - bayi
-        - gaman
-        - yanna
-      sentences:
-        - text: "Good morning."
-          tokens: ["suba", "udek"]
-          minUnit: 5
-        - text: "Good night."
-          tokens: ["suba", "raththiyek"]
-          minUnit: 5
-        - text: "Goodbye."
-          tokens: ["gaman", "yanna"]
-          minUnit: 5
-        - text: "Bye."
-          tokens: ["bayi"]
-          minUnit: 5
-
-# ======================================================
-# Section 02 — Introducing Yourself & Others
-# ======================================================
-
-Section02:
-  title: "Introducing Yourself & Others"
-  description: "Learn to introduce yourself and others with pronouns and basic structures."
-  units:
-
-    - id: 1
-      name: "Pronouns & Simple Sentences"
-      vocab:
-        - mama
-        - oya
-        - api
-      sentences:
-        - text: "I am {name}."
-          tokens: ["mama", "{name}"]
-          minUnit: 1
-        - text: "You are {name}."
-          tokens: ["oya", "{name}"]
-          minUnit: 1
-        - text: "We are friends."
-          tokens: ["api", "yaluwō"]
-          minUnit: 1
-
-    - id: 2
-      name: "Introducing Others"
-      vocab:
-        - eya
-        - mage
-        - yaluwō
-      sentences:
+        - text: "This is my friend."
+          tokens: ["me", "mage", "yalua"]
+          minUnit: 2
         - text: "He is my friend."
-          tokens: ["eya", "mage", "yaluwō"]
+          tokens: ["ohu", "mage", "yalua"]
           minUnit: 2
         - text: "She is my friend."
-          tokens: ["eya", "mage", "yaluwō"]
+          tokens: ["eya", "mage", "yalua"]
+          minUnit: 2
+        - text: "Thank you, you too."
+          tokens: ["sthuthiyi", "oyatat"]
           minUnit: 2
 
     - id: 3
-      name: "Polite Forms"
+      name: "Countries & Origin"
       vocab:
-        - oyā
-        - oyāla
-        - ayubowan
-      sentences:
-        - text: "Hello everyone!"
-          tokens: ["ayubowan", "oyāla"]
-          minUnit: 3
-        - text: "How are you all?"
-          tokens: ["oyāla", "kohomada"]
-          minUnit: 3
-        - text: "We are fine."
-          tokens: ["api", "hondai"]
-          minUnit: 3
-
-# ======================================================
-# Section 03 — Origins & Nationalities
-# ======================================================
-
-Section03:
-  title: "Origins & Nationalities"
-  description: "Learn to say where you and others are from."
-  units:
-
-    - id: 1
-      name: "Talking About Where You’re From"
-      vocab:
-        - mama
-        - oya
         - rata
-        - gena
-        - kohenda
-      sentences:
-        - text: "I am from Sri Lanka."
-          tokens: ["mama", "Sri_Lanka", "gena"]
-          minUnit: 1
-        - text: "Are you from Australia?"
-          tokens: ["oya", "Australia", "gena", "da"]
-          minUnit: 1
-        - text: "My country is Sri Lanka."
-          tokens: ["mage", "rata", "Sri_Lanka"]
-          minUnit: 1
-
-    - id: 2
-      name: "Countries & Nationalities"
-      vocab:
-        - Sri_Lanka
-        - Australia
-        - India
-      sentences:
-        - text: "He is from India."
-          tokens: ["eya", "India", "gena"]
-          minUnit: 2
-        - text: "We are from Australia."
-          tokens: ["api", "Australia", "gena"]
-          minUnit: 2
-
-# ======================================================
-# Section 04 — Age & Numbers
-# ======================================================
-
-Section04:
-  title: "Age & Numbers"
-  description: "Learn to ask and tell ages and count numbers."
-  units:
-
-    - id: 1
-      name: "Asking Age"
-      vocab:
-        - oya
-        - vayasa
-        - kiiyada
-        - da
-      sentences:
-        - text: "How old are you?"
-          tokens: ["oya", "vayasa", "kiiyada", "da"]
-          minUnit: 1
-
-    - id: 2
-      name: "Telling Age"
-      vocab:
         - mage
-        - vayasa
-        - vissayi
+        - oya
+        - oyaage
+        - mokak
+        - da
+        - srilankava
+        - australiya
+        - indiyava
+        - amerikava
+        - cheenaya
+        - japanaya
+        - kanadava
+        - pruthugalaya
+        - jermany
+        - france
+        - italiya
+        - ven
+        - gen
+        - kohen
+        - kohe
+        - methana
+        - othana
+        - owu
+        - nae
+        - neve
       sentences:
-        - text: "I am twenty years old."
-          tokens: ["mage", "vayasa", "vissayi"]
-          minUnit: 2
-
-    - id: 3
-      name: "Comparing Age"
-      vocab:
-        - ohugē
-        - ayagē
-        - vadā
-      sentences:
-        - text: "He is older than me."
-          tokens: ["ohugē", "vayasa", "vadā", "maṭa"]
+        - text: "What is your country?"
+          tokens: ["oyaage", "rata", "mokak", "da"]
+          minUnit: 3
+        - text: "My country is Sri Lanka."
+          tokens: ["mage", "rata", "srilankava"]
+          minUnit: 3
+        - text: "I am from Sri Lanka."
+          tokens: ["mama", "srilankava", "ven"]
+          minUnit: 3
+        - text: "Where are you from?"
+          tokens: ["oya", "kohen", "da"]
+          minUnit: 3
+        - text: "I am from Australia."
+          tokens: ["mama", "australiya", "ven"]
+          minUnit: 3
+        - text: "Are you from India?"
+          tokens: ["oya", "indiyava", "ven", "da"]
+          minUnit: 3
+        - text: "No, I am from China."
+          tokens: ["nae", "mama", "cheenaya", "ven"]
+          minUnit: 3
+        - text: "My friend is not from America."
+          tokens: ["mage", "yalua", "amerikava", "ven", "neve"]
           minUnit: 3
 
     - id: 4
-      name: "Numbers Practice"
+      name: "Age & Numbers"
       vocab:
+        - oya
+        - oyaage
+        - oyala
+        - oyalage
+        - ohuge
+        - eyage
+        - owunge
+        - ape
+        - nivasa
+        - potha
+        - yaluwō
+        - vayasa
+        - kiyada
+        - da
+        - vayasayi
+        - avurudu
+        - samanayi
+        - wada
+        - kuda
         - eka
         - deka
         - thuna
@@ -287,97 +188,118 @@ Section04:
         - ata
         - navaya
         - dahaya
+        - ekolaha
+        - dolaha
+        - dahathuna
+        - dahahathara
+        - pahalowa
+        - solaha
+        - dahahata
+        - dahaata
+        - dahanavaya
+        - vissa
+        - ekavissa
+        - devissa
+        - thunavissa
+        - hatharavissa
+        - pahavissa
+        - hayavissa
+        - hathavissa
+        - atavissa
+        - navayavissa
+        - thiha
+        - thihaeka
+        - thihadeka
+        - thihathuna
+        - thihahathara
+        - thihapaha
+        - thihahaya
+        - thihahatha
+        - thihaata
+        - thihanavaya
+        - hathaliha
       sentences:
-        - text: "Count from one to ten."
+        - text: "How old are you?"
+          tokens: ["oyaage", "vayasa", "kiyada", "da"]
+          minUnit: 4
+        - text: "My age is twenty."
+          tokens: ["mage", "vayasa", "vissa", "vayasayi"]
+          minUnit: 4
+        - text: "He is twenty years old."
+          tokens: ["ohu", "avurudu", "vissa", "vayasayi"]
+          minUnit: 4
+        - text: "Her age is not thirty."
+          tokens: ["eyage", "vayasa", "thiha", "neve"]
+          minUnit: 4
+        - text: "Our house is the same age."
+          tokens: ["ape", "nivasa", "samanayi"]
+          minUnit: 4
+        - text: "Their friend is older than me."
+          tokens: ["owunge", "yalua", "wada", "mama", "vayasayi"]
+          minUnit: 4
+        - text: "Count to ten."
           tokens: ["eka", "deka", "thuna", "hathara", "paha", "haya", "hatha", "ata", "navaya", "dahaya"]
           minUnit: 4
+        - text: "Count to forty."
+          tokens: ["eka", "deka", "thuna", "hathara", "paha", "haya", "hatha", "ata", "navaya", "dahaya", "ekolaha", "dolaha", "dahathuna", "dahahathara", "pahalowa", "solaha", "dahahata", "dahaata", "dahanavaya", "vissa", "ekavissa", "devissa", "thunavissa", "hatharavissa", "pahavissa", "hayavissa", "hathavissa", "atavissa", "navayavissa", "thiha", "thihaeka", "thihadeka", "thihathuna", "thihahathara", "thihapaha", "thihahaya", "thihahatha", "thihaata", "thihanavaya", "hathaliha"]
+          minUnit: 4
 
-# ======================================================
-# Section 05 — Communication & Speech
-# ======================================================
-
-Section05:
-  title: "Communication & Speech"
-  description: "Learn to do, speak, ask, and say words in Sinhala."
-  units:
-
-    - id: 1
-      name: "Doing Things — කරනවා"
+    - id: 5
+      name: "Communication & Speech"
       vocab:
         - mama
         - oya
         - api
-        - karanavā
-        - pāḍam
-        - kæma
-        - mokakda
-      sentences:
-        - text: "I study."
-          tokens: ["mama", "pāḍam", "karanavā"]
-          minUnit: 1
-        - text: "We are eating."
-          tokens: ["api", "kæma", "karanavā"]
-          minUnit: 1
-        - text: "What are you doing?"
-          tokens: ["oya", "mokakda", "karanavā"]
-          minUnit: 1
-
-    - id: 2
-      name: "Speaking — කතා කරනවා"
-      vocab:
-        - kathā
-        - karanavā
-      sentences:
-        - text: "I am speaking."
-          tokens: ["mama", "kathā", "karanavā"]
-          minUnit: 2
-        - text: "You are talking."
-          tokens: ["oya", "kathā", "karanavā"]
-          minUnit: 2
-
-    - id: 3
-      name: "Speaking Languages"
-      vocab:
-        - siṁhala
-        - ingrīsi
-        - tāmil
-        - chainīs
-      sentences:
-        - text: "I speak Sinhala."
-          tokens: ["mama", "siṁhala", "kathā", "karanavā"]
-          minUnit: 3
-        - text: "We speak Tamil."
-          tokens: ["api", "tāmil", "kathā", "karanavā"]
-          minUnit: 3
-        - text: "He speaks Chinese."
-          tokens: ["eya", "chainīs", "kathā", "karanavā"]
-          minUnit: 3
-
-    - id: 4
-      name: "Questions & Negation"
-      vocab:
+        - ohu
+        - owu
+        - nae
+        - naehae
+        - karanawa
+        - igenagannawa
+        - padam
+        - kema
+        - keli
+        - mokak
         - da
-        - næhæ
+        - katha
+        - kiyanawa
+        - kiyanne
+        - prashnaya
+        - pilithura
+        - sinhala
+        - ingrisi
+        - tamil
+        - chayinis
+        - sinhalaen
+        - ingriisiyen
+        - tamiyen
+        - chayinisen
+        - kohoma
       sentences:
-        - text: "Do you speak Sinhala?"
-          tokens: ["oya", "siṁhala", "kathā", "karanavā", "da"]
-          minUnit: 4
+        - text: "I am studying."
+          tokens: ["mama", "padam", "igenagannawa"]
+          minUnit: 5
+        - text: "We are eating."
+          tokens: ["api", "kema", "karanawa"]
+          minUnit: 5
+        - text: "What are you doing?"
+          tokens: ["oya", "mokak", "karanawa", "da"]
+          minUnit: 5
+        - text: "I speak Sinhala."
+          tokens: ["mama", "sinhala", "katha", "karanawa"]
+          minUnit: 5
+        - text: "Do you speak English?"
+          tokens: ["oya", "ingrisi", "katha", "karanawa", "da"]
+          minUnit: 5
         - text: "I do not speak Sinhala."
-          tokens: ["mama", "siṁhala", "kathā", "karanavā", "næhæ"]
-          minUnit: 4
-
-    - id: 5
-      name: "Saying Words — කියනවා"
-      vocab:
-        - kiyanavā
-        - kiyannē
-        - kohomada
-        - siṁhalen
-        - ingrīsiyen
-      sentences:
+          tokens: ["mama", "sinhala", "katha", "karanawa", "naehae"]
+          minUnit: 5
         - text: "How do you say 'Hello' in Sinhala?"
-          tokens: ["siṁhalen", "oya", "kiyannē", "kohomada"]
+          tokens: ["sinhalaen", "oya", "kiyanne", "kohoma", "da"]
           minUnit: 5
         - text: "We say 'Ayubowan.'"
-          tokens: ["api", "ayubowan", "kiyanavā"]
+          tokens: ["api", "ayubowan", "kiyanawa"]
+          minUnit: 5
+        - text: "He says thank you."
+          tokens: ["ohu", "sthuthiyi", "kiyanawa"]
           minUnit: 5

--- a/assets/Lessons/sections/section-01-introductions/words.yaml
+++ b/assets/Lessons/sections/section-01-introductions/words.yaml
@@ -1,5 +1,5 @@
 # Section 01 — Introductions & Essentials (Revised)
-# Core vocabulary for greetings, introductions, origin, feelings, and polite farewells
+# Core vocabulary for greetings, introductions, origin, feelings, age, and communication
 
 # ======================================================
 # 🪷 SECTION 01 — INTRODUCTIONS & ESSENTIALS
@@ -9,162 +9,160 @@
 section-01-words:
 
   unit-01-pronouns-greetings:
-    lesson-01-pronouns-basics:
+    lesson-01-pronouns:
       - { si: "මම", translit: "mama", en: "I / me" }
-      - { si: "ඔයා", translit: "oyā", en: "you" }
-      - { si: "ඔව්", translit: "owu", en: "yes" }
-      - { si: "නෑ", translit: "næ", en: "no" }
+      - { si: "ඔයා", translit: "oya", en: "you (casual)" }
+      - { si: "ඔහු", translit: "ohu", en: "he" }
+      - { si: "ඇය", translit: "eya", en: "she" }
+      - { si: "අපි", translit: "api", en: "we" }
+      - { si: "ඔවුන්", translit: "owun", en: "they" }
+
+    lesson-02-greetings-feelings:
+      - { si: "ආයුබෝවන්", translit: "ayubowan", en: "hello (formal)" }
+      - { si: "කොහොම", translit: "kohoma", en: "how" }
       - { si: "හොඳයි", translit: "hondayi", en: "good / fine" }
-      - { si: "ඒයා", translit: "eyā", en: "he / she (neutral)" }
-
-    lesson-02-how-are-you:
-      - { si: "ඔයාට", translit: "oyāta", en: "to you" }
-      - { si: "කොහොමද", translit: "kohomada", en: "how" }
-      - { si: "සනීපෙන්", translit: "sanīpen", en: "well / healthy" }
-      - { si: "සන්තෝෂයි", translit: "santhōshayi", en: "happy" }
-      - { si: "දුක්තයි", translit: "dukthayi", en: "sad / tired" }
-      - { si: "නැහැ", translit: "næhæ", en: "not / none" }
-
-    lesson-03-formal-greeting:
-      - { si: "ආයුබෝවන්", translit: "āyubōvan", en: "hello (formal)" }
-      - { si: "ඔබට", translit: "obata", en: "to you (formal)" }
-      - { si: "හොඳින්", translit: "hondin", en: "well / nicely" }
-      - { si: "ඉන්නවා", translit: "innavā", en: "to be / staying" }
+      - { si: "හොඳ", translit: "honda", en: "good" }
+      - { si: "සනීපෙන්", translit: "saniipen", en: "well / healthy" }
       - { si: "ස්තුතියි", translit: "sthuthiyi", en: "thank you" }
-      - { si: "ඔබටත්", translit: "obatat", en: "to you too" }
+
+    lesson-03-yes-no:
+      - { si: "ඔව්", translit: "owu", en: "yes" }
+      - { si: "නෑ", translit: "nae", en: "no" }
+      - { si: "නැහැ", translit: "naehae", en: "not / no" }
+      - { si: "ද", translit: "da", en: "question particle" }
 
     lesson-04-politeness:
-      - { si: "කරුණාකර", translit: "karunākar", en: "please" }
-      - { si: "සමාවෙන්න", translit: "samāvenna", en: "sorry / excuse me" }
-      - { si: "ඒකට", translit: "ekata", en: "for that" }
-      - { si: "ඇතුළට", translit: "æthulata", en: "inside" }
-      - { si: "එන්න", translit: "enna", en: "come" }
+      - { si: "කරුණාකර", translit: "karunakara", en: "please" }
+      - { si: "සමාවෙන්න", translit: "samavenna", en: "sorry / excuse me" }
+      - { si: "ඔයාට", translit: "oyata", en: "to you" }
+      - { si: "ඔබට", translit: "obata", en: "to you (formal)" }
+      - { si: "ඔයාටත්", translit: "oyatat", en: "to you too" }
 
     lesson-05-farewells:
-      - { si: "සුභ", translit: "suba", en: "good / blessing" }
-      - { si: "උදේක්", translit: "udek", en: "morning" }
-      - { si: "රාත්‍රියක්", translit: "rātriyak", en: "night" }
-      - { si: "බායි", translit: "bāyi", en: "bye (casual)" }
+      - { si: "සුභ", translit: "suba", en: "good / blessed" }
+      - { si: "උදේ", translit: "ude", en: "morning" }
+      - { si: "සවස", translit: "sawasa", en: "evening" }
+      - { si: "රාත්‍රිය", translit: "rathriya", en: "night" }
+      - { si: "බායි", translit: "bayi", en: "bye" }
       - { si: "ගමන්", translit: "gaman", en: "journey / trip" }
       - { si: "යන්න", translit: "yanna", en: "to go" }
 
 
 # ======================================================
 # 🌸 SECTION 02 — INTRODUCING YOURSELF
-# Unit 01 — Self-Identity & Names
+# Unit 02 — Self-Identity & Names
 # ======================================================
 
 section-02-words:
 
-  unit-01-introducing-yourself:
+  unit-02-introducing-yourself:
     lesson-01-possessives:
-      - { si: "මගේ", translit: "magē", en: "my" }
-      - { si: "ඔයාගේ", translit: "oyāgē", en: "your (casual)" }
+      - { si: "මගේ", translit: "mage", en: "my" }
+      - { si: "ඔයාගේ", translit: "oyaage", en: "your (casual)" }
+      - { si: "ඔබගේ", translit: "obage", en: "your (formal)" }
+      - { si: "ඔහුගේ", translit: "ohuge", en: "his" }
+      - { si: "ඇයගේ", translit: "eyage", en: "her" }
+      - { si: "අපේ", translit: "ape", en: "our" }
+      - { si: "ඔවුන්ගේ", translit: "owunge", en: "their" }
+
+    lesson-02-names:
       - { si: "නම", translit: "nama", en: "name" }
-      - { si: "මොකක්ද", translit: "mokakda", en: "what?" }
+      - { si: "මොකක්", translit: "mokak", en: "what" }
+      - { si: "කියන්නේ", translit: "kiyanne", en: "is called" }
+      - { si: "කියනවා", translit: "kiyanawa", en: "to say" }
+      - { si: "මේ", translit: "me", en: "this" }
+      - { si: "එයා", translit: "eya", en: "that person" }
 
-    lesson-02-introductions:
-      - { si: "මගේ", translit: "magē", en: "my" }
-      - { si: "{name}", translit: "{name}", en: "{name}" }
-      - { si: "යාලුවා", translit: "yāluwā", en: "friend" }
-      - { si: "ඒයා", translit: "eyā", en: "he / she (neutral)" }
+    lesson-03-relationships:
+      - { si: "යාලුවා", translit: "yalua", en: "friend" }
+      - { si: "යාලුවෝ", translit: "yaluwō", en: "friends" }
+      - { si: "පවුල", translit: "pawula", en: "family" }
+      - { si: "ගුරු", translit: "guru", en: "teacher" }
+      - { si: "ශිෂ්‍ය", translit: "shishya", en: "student" }
 
-    lesson-03-ask-names:
-      - { si: "ඔයාගේ", translit: "oyāgē", en: "your" }
-      - { si: "නම", translit: "nama", en: "name" }
-      - { si: "මොකක්ද", translit: "mokakda", en: "what?" }
-      - { si: "ඔබගේ", translit: "obagē", en: "your (formal)" }
-
-    lesson-04-polite-replies:
-      - { si: "හඳුවීම", translit: "hamuwīma", en: "meeting" }
+    lesson-04-pleasantries:
+      - { si: "හඳුවීම", translit: "handuwima", en: "meeting" }
       - { si: "සතුටක්", translit: "sathutak", en: "a pleasure" }
-      - { si: "ඔයාට", translit: "oyāta", en: "to you" }
+      - { si: "ඔයාට", translit: "oyata", en: "to you" }
+      - { si: "ඔයාටත්", translit: "oyatat", en: "to you too" }
       - { si: "ස්තුතියි", translit: "sthuthiyi", en: "thank you" }
       - { si: "හොඳින්", translit: "hondin", en: "well" }
-      - { si: "ඉන්නවා", translit: "innavā", en: "to be / stay" }
 
 
 # ======================================================
 # 🌍 SECTION 03 — COUNTRIES & ORIGIN
-# Unit 01 — Talking About Where You're From
+# Unit 03 — Talking About Where You're From
 # ======================================================
 
 section-03-words:
 
-  unit-01-countries-origin:
-    lesson-01-what-country:
-      - { si: "රට", translit: "raṭa", en: "country" }
-      - { si: "මොකක්ද", translit: "mokakda", en: "what?" }
-      - { si: "ඔයාගේ", translit: "oyāgē", en: "your" }
-      - { si: "මගේ", translit: "magē", en: "my" }
-      - { si: "ශ්‍රී ලංකාව", translit: "Sri Lankāva", en: "Sri Lanka" }
-      - { si: "ඕස්ට්‍රේලියාව", translit: "Ōstrēliyāva", en: "Australia" }
-      - { si: "ඉන්දියාව", translit: "Indiyāva", en: "India" }
-      - { si: "ඇමෙරිකාව", translit: "Amerikāva", en: "America" }
-      - { si: "ජපන්", translit: "Japan", en: "Japan" }
+  unit-03-countries-origin:
+    lesson-01-countries:
+      - { si: "රට", translit: "rata", en: "country" }
+      - { si: "ශ්‍රීලංකාව", translit: "srilankava", en: "Sri Lanka" }
+      - { si: "ඕස්ට්‍රේලියාව", translit: "australiya", en: "Australia" }
+      - { si: "ඉන්දියාව", translit: "indiyava", en: "India" }
+      - { si: "ඇමෙරිකාව", translit: "amerikava", en: "America" }
+      - { si: "චීනය", translit: "cheenaya", en: "China" }
+      - { si: "ජපානය", translit: "japanaya", en: "Japan" }
 
-    lesson-02-my-country:
-      - { si: "වි", translit: "vayi", en: "is (formal)" }
-      - { si: "හොඳ", translit: "honda", en: "good / nice" }
-      - { si: "රටක්", translit: "raṭak", en: "a country" }
-      - { si: "නෙ", translit: "ne", en: "isn't it? / right?" }
-
-    lesson-03-from-country:
-      - { si: "මම", translit: "mama", en: "I / me" }
+    lesson-02-origin-markers:
+      - { si: "වෙන්", translit: "ven", en: "from (suffix)" }
       - { si: "ගෙන්", translit: "gen", en: "from" }
-      - { si: "කොහෙන්ද", translit: "kohenda", en: "from where?" }
-      - { si: "ශ්‍රී ලංකාවෙන්", translit: "Sri Lankāven", en: "from Sri Lanka" }
-      - { si: "ඕස්ට්‍රේලියාවෙන්", translit: "Ōstrēliyāven", en: "from Australia" }
-      - { si: "ඉන්දියාවෙන්", translit: "Indiyāven", en: "from India" }
+      - { si: "කොහෙන්", translit: "kohen", en: "from where" }
+      - { si: "කොහේ", translit: "kohe", en: "where" }
+      - { si: "මෙතන", translit: "methana", en: "here" }
+      - { si: "ඔතන", translit: "othana", en: "there" }
 
-    lesson-04-are-you-from:
-      - { si: "ද", translit: "da", en: "question particle" }
-      - { si: "නෙවේ", translit: "nevē", en: "not / isn't" }
+    lesson-03-answers:
+      - { si: "මගේ", translit: "mage", en: "my" }
+      - { si: "ඔයාගේ", translit: "oyaage", en: "your" }
       - { si: "ඔව්", translit: "owu", en: "yes" }
-      - { si: "නෑ", translit: "næ", en: "no" }
-      - { si: "ඒත්", translit: "ēth", en: "but" }
+      - { si: "නෑ", translit: "nae", en: "no" }
+      - { si: "නෙවේ", translit: "neve", en: "is not" }
+      - { si: "දැක්ක", translit: "dakka", en: "saw" }
+
+    lesson-04-extra-countries:
+      - { si: "කැනඩාව", translit: "kanadava", en: "Canada" }
+      - { si: "පෘතුගාලය", translit: "pruthugalaya", en: "Portugal" }
+      - { si: "ජර්මනිය", translit: "jermany", en: "Germany" }
+      - { si: "ෆ්රන්ස්", translit: "france", en: "France" }
+      - { si: "ඉතාලිය", translit: "italiya", en: "Italy" }
+
 
 # ======================================================
-# Section 04 — Age & Numbers
-# Vocabulary for describing age, asking questions, and counting
+# 🕰️ SECTION 04 — AGE & NUMBERS
+# Unit 04 — Age, Counting, and Comparisons
 # ======================================================
 
 section-04-words:
 
-  unit-04-age:
-    lesson-01-pronouns-and-age:
-      - { si: "මම", translit: "mama", en: "I" }
-      - { si: "ඔයා", translit: "oyā", en: "you" }
+  unit-04-age-numbers:
+    lesson-01-asking-age:
       - { si: "වයස", translit: "vayasa", en: "age" }
-      - { si: "කිීයද", translit: "kiiyada", en: "how many / how much" }
-      - { si: "ද?", translit: "da?", en: "question particle" }
+      - { si: "කීයද", translit: "kiyada", en: "how many / how much" }
+      - { si: "ඔයාගේ", translit: "oyaage", en: "your" }
+      - { si: "ඔයාලගේ", translit: "oyalage", en: "your (plural)" }
+      - { si: "ඔයාලා", translit: "oyala", en: "you (plural)" }
+      - { si: "ද", translit: "da", en: "question particle" }
 
     lesson-02-stating-age:
-      - { si: "මගේ", translit: "magē", en: "my" }
-      - { si: "වයසක", translit: "vayasaka", en: "years old" }
-      - { si: "අවුරුදු", translit: "avurudu", en: "years (of age)" }
-      - { si: "විස්සයි", translit: "vissayi", en: "twenty" }
-      - { si: "දහනවයයි", translit: "dahanavayayi", en: "nineteen" }
-
-    lesson-03-comparing-age:
-      - { si: "ඔහුගේ", translit: "ohugē", en: "his" }
-      - { si: "ඇයගේ", translit: "ayagē", en: "her" }
-      - { si: "වඩා", translit: "vaḍā", en: "more / older" }
-      - { si: "යුවන", translit: "yuvana", en: "young" }
-      - { si: "වයස්කාර", translit: "vayaskāra", en: "old (person)" }
-      - { si: "එකම", translit: "ekama", en: "same" }
       - { si: "වයසයි", translit: "vayasayi", en: "is aged" }
+      - { si: "අවුරුදු", translit: "avurudu", en: "years (of age)" }
+      - { si: "සමානයි", translit: "samanayi", en: "is equal / same" }
+      - { si: "වඩා", translit: "wada", en: "more / older" }
+      - { si: "කුඩා", translit: "kuda", en: "smaller / younger" }
+      - { si: "ඔහුගේ", translit: "ohuge", en: "his" }
+      - { si: "ඇයගේ", translit: "eyage", en: "her" }
 
-    lesson-04-talking-age:
-      - { si: "මට", translit: "maṭa", en: "to me" }
-      - { si: "ඔහුට", translit: "ohuta", en: "to him" }
-      - { si: "ඇයට", translit: "ayata", en: "to her" }
-      - { si: "අවුරුදු", translit: "avurudu", en: "years" }
-      - { si: "අවුරුදු විස්සයි", translit: "avurudu vissayi", en: "twenty years old" }
-      - { si: "අවුරුදු දහයයි", translit: "avurudu dahayi", en: "ten years old" }
-      - { si: "අවුරුදු තිහයි", translit: "avurudu tihayi", en: "thirty years old" }
+    lesson-03-nouns-practice:
+      - { si: "නිවස", translit: "nivasa", en: "house" }
+      - { si: "පොත", translit: "potha", en: "book" }
+      - { si: "යාලුවෝ", translit: "yaluwō", en: "friends" }
+      - { si: "අපේ", translit: "ape", en: "our" }
+      - { si: "ඔවුන්ගේ", translit: "owunge", en: "their" }
 
-    lesson-05-numbers:
+    lesson-04-numbers-1-20:
       - { si: "එක", translit: "eka", en: "one" }
       - { si: "දෙක", translit: "deka", en: "two" }
       - { si: "තුන", translit: "thuna", en: "three" }
@@ -172,7 +170,7 @@ section-04-words:
       - { si: "පහ", translit: "paha", en: "five" }
       - { si: "හය", translit: "haya", en: "six" }
       - { si: "හත", translit: "hatha", en: "seven" }
-      - { si: "අට", translit: "aṭa", en: "eight" }
+      - { si: "අට", translit: "ata", en: "eight" }
       - { si: "නවය", translit: "navaya", en: "nine" }
       - { si: "දහය", translit: "dahaya", en: "ten" }
       - { si: "එකොළහ", translit: "ekolaha", en: "eleven" }
@@ -181,60 +179,78 @@ section-04-words:
       - { si: "දහහතර", translit: "dahahathara", en: "fourteen" }
       - { si: "පහළොව", translit: "pahalowa", en: "fifteen" }
       - { si: "සොළහ", translit: "solaha", en: "sixteen" }
-      - { si: "දහහත", translit: "dahahatha", en: "seventeen" }
-      - { si: "දහඅට", translit: "daha-ata", en: "eighteen" }
+      - { si: "දහහත", translit: "dahahata", en: "seventeen" }
+      - { si: "දහඅට", translit: "dahaata", en: "eighteen" }
       - { si: "දහනවය", translit: "dahanavaya", en: "nineteen" }
       - { si: "විස්ස", translit: "vissa", en: "twenty" }
+
+    lesson-05-numbers-21-40:
       - { si: "එකවිස්ස", translit: "ekavissa", en: "twenty-one" }
       - { si: "දෙවිස්ස", translit: "devissa", en: "twenty-two" }
+      - { si: "තුනවිස්ස", translit: "thunavissa", en: "twenty-three" }
+      - { si: "හතරවිස්ස", translit: "hatharavissa", en: "twenty-four" }
+      - { si: "පහවිස්ස", translit: "pahavissa", en: "twenty-five" }
+      - { si: "හයවිස්ස", translit: "hayavissa", en: "twenty-six" }
+      - { si: "හතවිස්ස", translit: "hathavissa", en: "twenty-seven" }
+      - { si: "අටවිස්ස", translit: "atavissa", en: "twenty-eight" }
+      - { si: "නවයවිස්ස", translit: "navayavissa", en: "twenty-nine" }
       - { si: "තිහ", translit: "thiha", en: "thirty" }
-      - { si: "හතලිහ", translit: "hataliha", en: "forty" }
-      - { si: "කීයද", translit: "kiyada", en: "how many" }
+      - { si: "තිහඑක", translit: "thihaeka", en: "thirty-one" }
+      - { si: "තිහදෙක", translit: "thihadeka", en: "thirty-two" }
+      - { si: "තිහතුන", translit: "thihathuna", en: "thirty-three" }
+      - { si: "තිහහතර", translit: "thihahathara", en: "thirty-four" }
+      - { si: "තිහපහ", translit: "thihapaha", en: "thirty-five" }
+      - { si: "තිහහය", translit: "thihahaya", en: "thirty-six" }
+      - { si: "තිහහත", translit: "thihahatha", en: "thirty-seven" }
+      - { si: "තිහාට", translit: "thihaata", en: "thirty-eight" }
+      - { si: "තිහනවය", translit: "thihanavaya", en: "thirty-nine" }
+      - { si: "හතලිහ", translit: "hathaliha", en: "forty" }
+
 
 # ======================================================
-# Section 05 — Communication & Speech
-# Core vocabulary for verbs of doing, speaking, and saying
+# 🗣️ SECTION 05 — COMMUNICATION & SPEECH
+# Unit 05 — Doing, Speaking, and Saying
 # ======================================================
 
 section-05-words:
 
-  unit-05-communication:
+  unit-05-communication-speech:
     lesson-01-doing:
-      - { si: "කරනවා", translit: "karanavā", en: "to do / doing" }
-      - { si: "මම", translit: "mama", en: "I" }
-      - { si: "ඔයා", translit: "oyā", en: "you" }
-      - { si: "අපි", translit: "api", en: "we" }
-      - { si: "පාඩම්", translit: "pāḍam", en: "lesson / study" }
-      - { si: "කෑම", translit: "kæma", en: "food" }
-      - { si: "මොකක්ද?", translit: "mokakda?", en: "what?" }
+      - { si: "කරනවා", translit: "karanawa", en: "to do / doing" }
+      - { si: "ඉගෙනගන්නවා", translit: "igenagannawa", en: "to study / learn" }
+      - { si: "පාඩම්", translit: "padam", en: "lessons / studies" }
+      - { si: "කෑම", translit: "kema", en: "food" }
+      - { si: "කෙළි", translit: "keli", en: "play" }
+      - { si: "මොකක්", translit: "mokak", en: "what" }
 
     lesson-02-speaking:
-      - { si: "කතා", translit: "kathā", en: "talk / speech" }
-      - { si: "කතා කරනවා", translit: "kathā karanavā", en: "to speak / to talk" }
-      - { si: "මම", translit: "mama", en: "I" }
-      - { si: "ඔයා", translit: "oyā", en: "you" }
-      - { si: "අපි", translit: "api", en: "we" }
+      - { si: "කතා", translit: "katha", en: "talk / speech" }
+      - { si: "කියනවා", translit: "kiyanawa", en: "to say" }
+      - { si: "කියන්නේ", translit: "kiyanne", en: "is saying" }
+      - { si: "ප්‍රශ්නය", translit: "prashnaya", en: "question" }
+      - { si: "පිළිතුර", translit: "pilithura", en: "answer" }
 
     lesson-03-languages:
-      - { si: "සිංහල", translit: "siṁhala", en: "Sinhala" }
-      - { si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English" }
-      - { si: "තාමිල්", translit: "tāmil", en: "Tamil" }
-      - { si: "චයිනිස්", translit: "chainīs", en: "Chinese" }
-      - { si: "අපි", translit: "api", en: "we" }
-      - { si: "කතා කරනවා", translit: "kathā karanavā", en: "to speak / to talk" }
+      - { si: "සිංහල", translit: "sinhala", en: "Sinhala" }
+      - { si: "ඉංග්‍රීසි", translit: "ingrisi", en: "English" }
+      - { si: "තාමිල්", translit: "tamil", en: "Tamil" }
+      - { si: "චයිනිස්", translit: "chayinis", en: "Chinese" }
+      - { si: "සිංහලෙන්", translit: "sinhalaen", en: "in Sinhala" }
+      - { si: "ඉංග්‍රීසියෙන්", translit: "ingriisiyen", en: "in English" }
+      - { si: "තාමිල්ෙන්", translit: "tamiyen", en: "in Tamil" }
+      - { si: "චයිනිස්ෙන්", translit: "chayinisen", en: "in Chinese" }
 
     lesson-04-questions-negation:
-      - { si: "ද?", translit: "da?", en: "question particle" }
-      - { si: "නැහැ", translit: "næhæ", en: "not / no" }
-      - { si: "කතා කරනවා", translit: "kathā karanavā", en: "to speak / to talk" }
-      - { si: "සිංහල", translit: "siṁhala", en: "Sinhala" }
-      - { si: "ඉංග්‍රීසි", translit: "ingrīsi", en: "English" }
-      - { si: "මම", translit: "mama", en: "I" }
+      - { si: "ද", translit: "da", en: "question particle" }
+      - { si: "නැහැ", translit: "naehae", en: "not / no" }
+      - { si: "නෙවේ", translit: "neve", en: "is not" }
+      - { si: "ඔව්", translit: "owu", en: "yes" }
+      - { si: "නෑ", translit: "nae", en: "no" }
 
-    lesson-05-saying:
-      - { si: "කියනවා", translit: "kiyanavā", en: "to say / to tell" }
-      - { si: "කියන්නේ", translit: "kiyannē", en: "is saying / called" }
-      - { si: "කොහොමද", translit: "kohomada", en: "how?" }
-      - { si: "සිංහලෙන්", translit: "siṁhalen", en: "in Sinhala" }
-      - { si: "ඉංග්‍රීසියෙන්", translit: "ingrīsiyen", en: "in English" }
-      - { si: "ඔයා", translit: "oyā", en: "you" }
+    lesson-05-utilities:
+      - { si: "මොකක්ද", translit: "mokakda", en: "what is it?" }
+      - { si: "කොහොම", translit: "kohoma", en: "how" }
+      - { si: "පත්තර", translit: "patthara", en: "newspaper" }
+      - { si: "පාඩම්", translit: "padam", en: "lessons" }
+      - { si: "කියවන්න", translit: "kiyawanna", en: "to read" }
+      - { si: "ඇත්තට", translit: "aettata", en: "really" }

--- a/data/s1u2.lessons.json
+++ b/data/s1u2.lessons.json
@@ -1,6 +1,6 @@
 {
   "unitId": "s1u2",
-  "title": "Yes/No & ‘Am’ Forms",
+  "title": "Countries & Origin",
   "skills": [
     {
       "skillId": "s1u2-skill-01",
@@ -8,15 +8,107 @@
       "levels": [
         {
           "levelId": "s1u2-skill-01-l1",
-          "lessonCount": 2,
+          "lessonCount": 4,
           "lessons": [
-            { "lessonId": "lesson-01", "title": "Lesson 1", "objectives": [], "content_blocks": [] },
-            { "lessonId": "lesson-02", "title": "Lesson 2", "objectives": [], "content_blocks": [] }
+            {
+              "lessonId": "lesson-01",
+              "title": "What is your country?",
+              "duration_min": 7,
+              "xp_reward": 10,
+              "objectives": [
+                "Ask about someone’s country using කොහෙන්ද?",
+                "Learn key country names"
+              ],
+              "vocab": [
+                {"si": "රට", "translit": "rata", "en": "country"},
+                {"si": "ඔයාගේ", "translit": "oyaage", "en": "your"},
+                {"si": "මගේ", "translit": "mage", "en": "my"},
+                {"si": "ශ්‍රීලංකාව", "translit": "srilankava", "en": "Sri Lanka"},
+                {"si": "ඕස්ට්‍රේලියාව", "translit": "australiya", "en": "Australia"},
+                {"si": "කොහෙන්", "translit": "kohen", "en": "from where"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Pattern: [possessive] + රට — rata — country. Use කොහෙන්ද? to ask \"from where?\""},
+                {"type": "MINI_EXAMPLE", "body": "ඔයාගේ රට මොකක්ද? — oyāge rata mokakda? — What is your country?"},
+                {"type": "PRACTICE", "body": "Match countries with Sinhala names, then record the question aloud."}
+              ]
+            },
+            {
+              "lessonId": "lesson-02",
+              "title": "My country is …",
+              "duration_min": 7,
+              "xp_reward": 10,
+              "objectives": [
+                "Say My country is …",
+                "Build answers with yes/no"
+              ],
+              "vocab": [
+                {"si": "මගේ", "translit": "mage", "en": "my"},
+                {"si": "රට", "translit": "rata", "en": "country"},
+                {"si": "ඇමෙරිකාව", "translit": "amerikava", "en": "America"},
+                {"si": "ඉන්දියාව", "translit": "indiyava", "en": "India"},
+                {"si": "ඔව්", "translit": "owu", "en": "yes"},
+                {"si": "නෑ", "translit": "nae", "en": "no"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Statement: මගේ රට ___ . Drop \"is\" — Sinhala doesn’t need a copula here."},
+                {"type": "DIALOGUE", "body": "A: මගේ රට ශ්‍රීලංකාව.\nB: ඔව්, මගේ රටත් ශ්‍රීලංකාව."},
+                {"type": "PRACTICE", "body": "Flashcards with new countries, then create your own sentences."}
+              ]
+            },
+            {
+              "lessonId": "lesson-03",
+              "title": "I’m from …",
+              "duration_min": 8,
+              "xp_reward": 12,
+              "objectives": [
+                "Use ___ වෙන් / ___ ගෙන් for origin",
+                "Answer where you are from"
+              ],
+              "vocab": [
+                {"si": "මම", "translit": "mama", "en": "I"},
+                {"si": "වෙන්", "translit": "ven", "en": "from"},
+                {"si": "ගෙන්", "translit": "gen", "en": "from"},
+                {"si": "චීනය", "translit": "cheenaya", "en": "China"},
+                {"si": "ජපානය", "translit": "japanaya", "en": "Japan"},
+                {"si": "නෙවේ", "translit": "neve", "en": "is not"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Attach වෙන් (ven) to a place: ශ්‍රීලංකාව + වෙන් → ශ්‍රීලංකාවෙන්. Use නැහැ / නෙවේ for negatives."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔයා කොහෙන්ද?\nB: මම චීනයෙන්."},
+                {"type": "PRACTICE", "body": "Build origin sentences with positive + negative variations."}
+              ]
+            },
+            {
+              "lessonId": "lesson-04",
+              "title": "Are you from …?",
+              "duration_min": 9,
+              "xp_reward": 12,
+              "objectives": [
+                "Form yes/no origin questions",
+                "Answer naturally with නෙවේ"
+              ],
+              "vocab": [
+                {"si": "ඔයා", "translit": "oya", "en": "you"},
+                {"si": "ද", "translit": "da", "en": "question particle"},
+                {"si": "කැනඩාව", "translit": "kanadava", "en": "Canada"},
+                {"si": "ප්‍රෂ්නය", "translit": "prashnaya", "en": "question"},
+                {"si": "නෙවේ", "translit": "neve", "en": "is not"},
+                {"si": "ඔව්", "translit": "owu", "en": "yes"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Question: [place] + වෙන් + ද? Answer: ඔව් / නෑ, මම … නෙවේ."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔයා ඉන්දියාවේන් ද?\nB: නෑ, මම කැනඩාවෙන්."},
+                {"type": "PRACTICE", "body": "Roleplay mini-dialogues swapping countries for drill variety."}
+              ]
+            }
           ],
           "review": {
             "type": "review",
             "title": "Lesson Review",
-            "content_blocks": []
+            "content_blocks": [
+              {"type": "SUMMARY", "body": "Review: ask where from, answer with වෙන්/ගෙන්, and use නෙවේ for natural negatives."}
+            ]
           }
         }
       ]

--- a/data/s1u4.lessons.json
+++ b/data/s1u4.lessons.json
@@ -1,6 +1,6 @@
 {
   "unitId": "s1u4",
-  "title": "Pronouns 1",
+  "title": "Age & Numbers",
   "skills": [
     {
       "skillId": "s1u4-skill-01",
@@ -8,16 +8,129 @@
       "levels": [
         {
           "levelId": "s1u4-skill-01-l1",
-          "lessonCount": 3,
+          "lessonCount": 5,
           "lessons": [
-            { "lessonId": "lesson-01", "title": "Lesson 1", "objectives": [], "content_blocks": [] },
-            { "lessonId": "lesson-02", "title": "Lesson 2", "objectives": [], "content_blocks": [] },
-            { "lessonId": "lesson-03", "title": "Lesson 3", "objectives": [], "content_blocks": [] }
+            {
+              "lessonId": "lesson-01",
+              "title": "Asking age",
+              "duration_min": 6,
+              "xp_reward": 10,
+              "objectives": [
+                "Ask How old are you?",
+                "Use plural you (ඔයාලා)"
+              ],
+              "vocab": [
+                {"si": "ඔයාගේ", "translit": "oyaage", "en": "your"},
+                {"si": "වයස", "translit": "vayasa", "en": "age"},
+                {"si": "කීයද", "translit": "kiyada", "en": "how many"},
+                {"si": "ද", "translit": "da", "en": "question particle"},
+                {"si": "ඔයාලා", "translit": "oyala", "en": "you (plural)"},
+                {"si": "ඔයාලගේ", "translit": "oyalage", "en": "your (plural)"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Frame questions: ඔයාගේ වයස කීයද? / ඔයාලගේ වයස කීයද?"},
+                {"type": "MINI_EXAMPLE", "body": "ඔයාගේ වයස කීයද? — oyāge vayasa kiyāda?"},
+                {"type": "PRACTICE", "body": "Drill singular vs plural questions with audio prompts."}
+              ]
+            },
+            {
+              "lessonId": "lesson-02",
+              "title": "Telling age",
+              "duration_min": 7,
+              "xp_reward": 10,
+              "objectives": [
+                "Say My age is …",
+                "Add years (අවුරුදු)"
+              ],
+              "vocab": [
+                {"si": "මගේ", "translit": "mage", "en": "my"},
+                {"si": "වයස", "translit": "vayasa", "en": "age"},
+                {"si": "විස්ස", "translit": "vissa", "en": "twenty"},
+                {"si": "අවුරුදු", "translit": "avurudu", "en": "years"},
+                {"si": "වයසයි", "translit": "vayasayi", "en": "is aged"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Statement: මගේ වයස විස්සයි. Optionally add අවුරුදු for clarity."},
+                {"type": "BIG_EXAMPLE", "body": "A: ඔයාගේ වයස කීයද?\nB: මගේ වයස විස්සයි."},
+                {"type": "PRACTICE", "body": "Substitute different numbers to answer the question."}
+              ]
+            },
+            {
+              "lessonId": "lesson-03",
+              "title": "Comparing age",
+              "duration_min": 8,
+              "xp_reward": 12,
+              "objectives": [
+                "Use වඩා / කුඩා / සමානයි",
+                "Talk about his/her age"
+              ],
+              "vocab": [
+                {"si": "ඔහුගේ", "translit": "ohuge", "en": "his"},
+                {"si": "ඇයගේ", "translit": "eyage", "en": "her"},
+                {"si": "වඩා", "translit": "wada", "en": "older / more"},
+                {"si": "කුඩා", "translit": "kuda", "en": "younger / small"},
+                {"si": "සමානයි", "translit": "samanayi", "en": "is the same"},
+                {"si": "නෙවේ", "translit": "neve", "en": "is not"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Use ප්‍රතිසංයෝග: ඔහුගේ වයස මට වඩා ලොකුයි / සමානයි."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔහුගේ වයස මට වඩා ද?\nB: නැහැ, සමානයි."},
+                {"type": "PRACTICE", "body": "Compare ages of friends, siblings, and classmates."}
+              ]
+            },
+            {
+              "lessonId": "lesson-04",
+              "title": "Numbers 1–20",
+              "duration_min": 9,
+              "xp_reward": 12,
+              "objectives": [
+                "Count from 1 to 20",
+                "Use numbers in age sentences"
+              ],
+              "vocab": [
+                {"si": "එක", "translit": "eka", "en": "one"},
+                {"si": "දහය", "translit": "dahaya", "en": "ten"},
+                {"si": "එකොළහ", "translit": "ekolaha", "en": "eleven"},
+                {"si": "පහළොව", "translit": "pahalowa", "en": "fifteen"},
+                {"si": "දහඅට", "translit": "dahaata", "en": "eighteen"},
+                {"si": "විස්ස", "translit": "vissa", "en": "twenty"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Group numbers into 1–5, 6–10, teens. Teens start with දහ- (daha-)."},
+                {"type": "PRACTICE", "body": "Tap tiles in order, then read each number aloud."},
+                {"type": "PRACTICE", "body": "Answer: ඔහුගේ වයස කීයද? using different numbers."}
+              ]
+            },
+            {
+              "lessonId": "lesson-05",
+              "title": "Numbers 21–40",
+              "duration_min": 9,
+              "xp_reward": 12,
+              "objectives": [
+                "Count 21–40",
+                "Reuse numbers in age comparisons"
+              ],
+              "vocab": [
+                {"si": "එකවිස්ස", "translit": "ekavissa", "en": "twenty-one"},
+                {"si": "දෙවිස්ස", "translit": "devissa", "en": "twenty-two"},
+                {"si": "හතරවිස්ස", "translit": "hatharavissa", "en": "twenty-four"},
+                {"si": "තිහ", "translit": "thiha", "en": "thirty"},
+                {"si": "තිහහය", "translit": "thihahaya", "en": "thirty-six"},
+                {"si": "හතලිහ", "translit": "hathaliha", "en": "forty"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Twenty-something = විස්ස + number. Thirty-something = තිහ + number."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔවුන්ගේ වයස හතලිහ නෙවේ?\nB: නෑ, තිහහයයි."},
+                {"type": "PRACTICE", "body": "Number ladder drill 21→40 with quick recall."}
+              ]
+            }
           ],
           "review": {
             "type": "review",
             "title": "Lesson Review",
-            "content_blocks": []
+            "content_blocks": [
+              {"type": "SUMMARY", "body": "Review: asking age, giving age, comparing ages, and counting 1–40."}
+            ]
           }
         }
       ]

--- a/data/s1u5.lessons.json
+++ b/data/s1u5.lessons.json
@@ -1,6 +1,6 @@
 {
   "unitId": "s1u5",
-  "title": "Possessives",
+  "title": "Communication & Speech",
   "skills": [
     {
       "skillId": "s1u5-skill-01",
@@ -8,15 +8,129 @@
       "levels": [
         {
           "levelId": "s1u5-skill-01-l1",
-          "lessonCount": 2,
+          "lessonCount": 5,
           "lessons": [
-            { "lessonId": "lesson-01", "title": "Lesson 1", "objectives": [], "content_blocks": [] },
-            { "lessonId": "lesson-02", "title": "Lesson 2", "objectives": [], "content_blocks": [] }
+            {
+              "lessonId": "lesson-01",
+              "title": "Doing things",
+              "duration_min": 6,
+              "xp_reward": 10,
+              "objectives": [
+                "Use කරනවා with everyday actions",
+                "Ask මොකක්ද? for what"
+              ],
+              "vocab": [
+                {"si": "කරනවා", "translit": "karanawa", "en": "to do"},
+                {"si": "ඉගෙනගන්නවා", "translit": "igenagannawa", "en": "to study"},
+                {"si": "පාඩම්", "translit": "padam", "en": "lessons"},
+                {"si": "කෑම", "translit": "kema", "en": "food"},
+                {"si": "මොකක්", "translit": "mokak", "en": "what"},
+                {"si": "ද", "translit": "da", "en": "question particle"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Pattern: [pronoun] + [activity] + කරනවා."},
+                {"type": "MINI_EXAMPLE", "body": "ඔයා මොකක් කරනවාද? — oyā mokak karanawāda?"},
+                {"type": "PRACTICE", "body": "Swap verbs (study/eat/play) while keeping the question form."}
+              ]
+            },
+            {
+              "lessonId": "lesson-02",
+              "title": "Speaking",
+              "duration_min": 6,
+              "xp_reward": 10,
+              "objectives": [
+                "Combine කතා + කරනවා",
+                "State who is talking"
+              ],
+              "vocab": [
+                {"si": "කතා", "translit": "katha", "en": "talk"},
+                {"si": "මම", "translit": "mama", "en": "I"},
+                {"si": "ඔයා", "translit": "oya", "en": "you"},
+                {"si": "අපි", "translit": "api", "en": "we"},
+                {"si": "ඔහු", "translit": "ohu", "en": "he"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Speaking = කතා + කරනවා. No extra verb needed."},
+                {"type": "DIALOGUE", "body": "A: ඔයා කතා කරනවාද?\nB: ඔව්, මම කතා කරනවා."},
+                {"type": "PRACTICE", "body": "Match pronouns to sentences, then record each line."}
+              ]
+            },
+            {
+              "lessonId": "lesson-03",
+              "title": "Languages",
+              "duration_min": 7,
+              "xp_reward": 10,
+              "objectives": [
+                "Name Sinhala, English, Tamil, Chinese",
+                "Say I speak …"
+              ],
+              "vocab": [
+                {"si": "සිංහල", "translit": "sinhala", "en": "Sinhala"},
+                {"si": "ඉංග්‍රීසි", "translit": "ingrisi", "en": "English"},
+                {"si": "තාමිල්", "translit": "tamil", "en": "Tamil"},
+                {"si": "චයිනිස්", "translit": "chayinis", "en": "Chinese"},
+                {"si": "සිංහලෙන්", "translit": "sinhalaen", "en": "in Sinhala"},
+                {"si": "ඉංග්‍රීසියෙන්", "translit": "ingriisiyen", "en": "in English"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Use language name + කතා කරනවා for \"speak\". Add -ෙන් for \"in [language]\"."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔයා සිංහල කතා කරනවාද?\nB: ඔව්, මම සිංහල කතා කරනවා."},
+                {"type": "PRACTICE", "body": "Mix and match pronouns with language tiles."}
+              ]
+            },
+            {
+              "lessonId": "lesson-04",
+              "title": "Questions & negation",
+              "duration_min": 7,
+              "xp_reward": 12,
+              "objectives": [
+                "Ask Do you speak …?",
+                "Answer with නැහැ / නෙවේ"
+              ],
+              "vocab": [
+                {"si": "නැහැ", "translit": "naehae", "en": "not / no"},
+                {"si": "නෙවේ", "translit": "neve", "en": "is not"},
+                {"si": "ඔව්", "translit": "owu", "en": "yes"},
+                {"si": "නෑ", "translit": "nae", "en": "no"},
+                {"si": "ප්‍රශ්නය", "translit": "prashnaya", "en": "question"},
+                {"si": "පිළිතුර", "translit": "pilithura", "en": "answer"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Negative pattern: මම සිංහල කතා කරනවා නැහැ / නෙවේ."},
+                {"type": "MINI_DIALOGUE", "body": "A: ඔයා ඉංග්‍රීසි කතා කරනවාද?\nB: නැහැ, මම සිංහල කතා කරනවා."},
+                {"type": "PRACTICE", "body": "Choose the correct positive or negative response."}
+              ]
+            },
+            {
+              "lessonId": "lesson-05",
+              "title": "How do you say …?",
+              "duration_min": 8,
+              "xp_reward": 12,
+              "objectives": [
+                "Use කියන්නේ කොහොමද?",
+                "Give translations with කියනවා"
+              ],
+              "vocab": [
+                {"si": "කියන්නේ", "translit": "kiyanne", "en": "how to say"},
+                {"si": "කියනවා", "translit": "kiyanawa", "en": "to say"},
+                {"si": "කොහොම", "translit": "kohoma", "en": "how"},
+                {"si": "සිංහලෙන්", "translit": "sinhalaen", "en": "in Sinhala"},
+                {"si": "ඉංග්‍රීසියෙන්", "translit": "ingriisiyen", "en": "in English"},
+                {"si": "ස්තුතියි", "translit": "sthuthiyi", "en": "thank you"}
+              ],
+              "content_blocks": [
+                {"type": "CONCEPT", "body": "Question: \"Hello\" සිංහලෙන් ඔයා කියන්නේ කොහොමද? Answer: ආයුබෝවන් කියනවා."},
+                {"type": "DIALOGUE", "body": "A: \"Thank you\" සිංහලෙන් ඔයා කියන්නේ කොහොමද?\nB: ස්තුතියි කියනවා."},
+                {"type": "PRACTICE", "body": "Give translations between Sinhala and English with prompts."}
+              ]
+            }
           ],
           "review": {
             "type": "review",
             "title": "Lesson Review",
-            "content_blocks": []
+            "content_blocks": [
+              {"type": "SUMMARY", "body": "Review: everyday actions, speaking languages, asking and negating, and saying words in Sinhala."}
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Reorganised the Sinhala word bank for Section 01 to provide single-token vocabulary across greetings, introductions, countries, age, numbers, and communication themes.
- Rebuilt Section 01 sentences with natural Sinhala questions, answers, and drills that align with the updated vocabulary and placeholders.
- Authored detailed lesson plans for units s1u2, s1u4, and s1u5 covering origin, age & numbers, and communication skills respectively.

## Testing
- `python -m json.tool data/s1u2.lessons.json`
- `python -m json.tool data/s1u4.lessons.json`
- `python -m json.tool data/s1u5.lessons.json`


------
https://chatgpt.com/codex/tasks/task_e_68e2e62ded2c833098b996b2434e3778